### PR TITLE
Direct3D Initialization Abstraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ cmake-build-debug
 Debug
 x64
 Release
+RelWithDebInfo

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ out
 cmake-build-debug
 Debug
 x64
+Release

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.sln
 *.vcxproj
 *.vcxproj.filters
+*.vcxproj.user
+*.dir
+
 
 # Build folders and files
 build
@@ -13,4 +16,5 @@ cmake_install.cmake
 CMakeCache.txt
 out
 cmake-build-debug
-
+Debug
+x64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,6 @@ file(GLOB_RECURSE  SRCS
 
 add_executable(${CMAKE_PROJECT_NAME} WIN32 DX_Renderer/main.cpp ${SRCS})
 
-#include_directories("DX_Renderer/Core")
+set_property(TARGET ${CMAKE_PROJECT_NAME} PROPERTY CXX_STANDARD 17)
 
 target_link_libraries(DX_Renderer PRIVATE "d3d12.lib" "dxgi.lib" "d3dcompiler.lib")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ file(GLOB_RECURSE  SRCS
         "DX_Renderer/*.hpp")
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-	add_compile_definitions(DEBUG=1)
+	target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE DEBUG=1)
 endif()
 
 add_executable(${CMAKE_PROJECT_NAME} WIN32 DX_Renderer/main.cpp ${SRCS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,14 @@ cmake_minimum_required(VERSION 3.14)
 
 project(DX_Renderer VERSION 0.0.1)
 
-add_executable(${CMAKE_PROJECT_NAME} WIN32 src/main.cpp)
+set(warnings "/W4 /WX /EHsc")
 
-# Linking with D3D12 components
-target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE "d3d12.lib" "dxgi.lib" "d3dcompiler.lib")
+file(GLOB_RECURSE  SRCS
+        "DX_Renderer/Core/*.cpp"
+        "DX_Renderer/Core/*.hpp")
+
+add_executable(${CMAKE_PROJECT_NAME} WIN32 DX_Renderer/main.cpp ${SRCS})
+
+#include_directories("DX_Renderer/Core")
+
+target_link_libraries(DX_Renderer PRIVATE "d3d12.lib" "dxgi.lib" "d3dcompiler.lib")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,12 @@ project(DX_Renderer VERSION 0.0.1)
 set(warnings "/W4 /WX /EHsc")
 
 file(GLOB_RECURSE  SRCS
-        "DX_Renderer/Core/*.cpp"
-        "DX_Renderer/Core/*.hpp")
+        "DX_Renderer/*.cpp"
+        "DX_Renderer/*.hpp")
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+	add_compile_definitions(DEBUG=1)
+endif()
 
 add_executable(${CMAKE_PROJECT_NAME} WIN32 DX_Renderer/main.cpp ${SRCS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,7 @@ file(GLOB_RECURSE  SRCS
         "DX_Renderer/*.cpp"
         "DX_Renderer/*.hpp")
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-	target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE DEBUG=1)
-endif()
+add_compile_definitions(WIN32_LEAN_AND_MEAN)
 
 add_executable(${CMAKE_PROJECT_NAME} WIN32 DX_Renderer/main.cpp ${SRCS})
 

--- a/DX_Renderer/Core/Components/Command List/GraphicsCommandList.cpp
+++ b/DX_Renderer/Core/Components/Command List/GraphicsCommandList.cpp
@@ -16,11 +16,15 @@ namespace DXR
 
 	inline void GraphicsCommandList::CreateCommandAllocator(GraphicsDevice& device)
 	{
+		INFO_LOG(L"Creating Command Allocator\n");
 		DXCall(device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&this->m_command_allocator)));
+		SUCCESS_LOG(L"Command Allocator Created\n");
 	}
 
 	inline void GraphicsCommandList::CreateCommandList(GraphicsDevice& device)
 	{
+		INFO_LOG(L"Creating Graphics Command List\n");
 		DXCall(device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, this->m_command_allocator.Get(),nullptr,IID_PPV_ARGS(&this->m_command_list)));
+		SUCCESS_LOG(L"Graphics Command List Created\n");
 	}
 }

--- a/DX_Renderer/Core/Components/Command List/GraphicsCommandList.cpp
+++ b/DX_Renderer/Core/Components/Command List/GraphicsCommandList.cpp
@@ -14,6 +14,11 @@ namespace DXR
 		return this->m_command_list.Get();
 	}
 
+	ID3D12GraphicsCommandList* GraphicsCommandList::GetRAWInterface() const
+	{
+		return this->m_command_list.Get();
+	}
+
 	inline void GraphicsCommandList::CreateCommandAllocator(GraphicsDevice& device)
 	{
 		INFO_LOG(L"Creating Command Allocator\n");

--- a/DX_Renderer/Core/Components/Command List/GraphicsCommandList.cpp
+++ b/DX_Renderer/Core/Components/Command List/GraphicsCommandList.cpp
@@ -1,0 +1,26 @@
+#include "GraphicsCommandList.hpp"
+#include "../../../Tooling/Validate.hpp"
+
+namespace DXR
+{
+	GraphicsCommandList::GraphicsCommandList(GraphicsDevice& device)
+	{
+		this->CreateCommandAllocator(device);
+		this->CreateCommandList(device);
+	}
+
+	ID3D12GraphicsCommandList* GraphicsCommandList::operator->()
+	{
+		return this->m_command_list.Get();
+	}
+
+	inline void GraphicsCommandList::CreateCommandAllocator(GraphicsDevice& device)
+	{
+		DXCall(device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&this->m_command_allocator)));
+	}
+
+	inline void GraphicsCommandList::CreateCommandList(GraphicsDevice& device)
+	{
+		DXCall(device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, this->m_command_allocator.Get(),nullptr,IID_PPV_ARGS(&this->m_command_list)));
+	}
+}

--- a/DX_Renderer/Core/Components/Command List/GraphicsCommandList.hpp
+++ b/DX_Renderer/Core/Components/Command List/GraphicsCommandList.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <d3d12.h>
+#include <wrl.h>
+#include "../GraphicsDevice.hpp"
+
+namespace DXR
+{
+	using namespace Microsoft;
+
+	class GraphicsCommandList
+	{
+	public:
+	private:
+		WRL::ComPtr<ID3D12CommandAllocator> m_command_allocator;
+		WRL::ComPtr<ID3D12GraphicsCommandList> m_command_list;
+	public:
+		GraphicsCommandList(GraphicsDevice& device);
+		ID3D12GraphicsCommandList* operator->();
+	private:
+		inline void CreateCommandAllocator(GraphicsDevice& device);
+		inline void CreateCommandList(GraphicsDevice& device);
+	};
+}

--- a/DX_Renderer/Core/Components/Command List/GraphicsCommandList.hpp
+++ b/DX_Renderer/Core/Components/Command List/GraphicsCommandList.hpp
@@ -17,6 +17,7 @@ namespace DXR
 		WRL::ComPtr<ID3D12GraphicsCommandList> m_command_list;
 	public:
 		ID3D12GraphicsCommandList* operator->();
+		ID3D12GraphicsCommandList* GetRAWInterface() const;
 	private:
 		GraphicsCommandList(GraphicsDevice& device);
 		inline void CreateCommandAllocator(GraphicsDevice& device);

--- a/DX_Renderer/Core/Components/Command List/GraphicsCommandList.hpp
+++ b/DX_Renderer/Core/Components/Command List/GraphicsCommandList.hpp
@@ -8,16 +8,17 @@ namespace DXR
 {
 	using namespace Microsoft;
 
-	class GraphicsCommandList
+	struct GraphicsCommandList
 	{
 	public:
+		friend GraphicsDevice;
 	private:
 		WRL::ComPtr<ID3D12CommandAllocator> m_command_allocator;
 		WRL::ComPtr<ID3D12GraphicsCommandList> m_command_list;
 	public:
-		GraphicsCommandList(GraphicsDevice& device);
 		ID3D12GraphicsCommandList* operator->();
 	private:
+		GraphicsCommandList(GraphicsDevice& device);
 		inline void CreateCommandAllocator(GraphicsDevice& device);
 		inline void CreateCommandList(GraphicsDevice& device);
 	};

--- a/DX_Renderer/Core/Components/Command Queue/CommandQueue.cpp
+++ b/DX_Renderer/Core/Components/Command Queue/CommandQueue.cpp
@@ -1,4 +1,5 @@
 #include "CommandQueue.hpp"
+#include "../Fence.hpp"
 
 namespace DXR 
 {
@@ -10,6 +11,13 @@ namespace DXR
 	ID3D12CommandQueue* CommandQueue::GetCommandQueueRawPtr()
 	{
 		return this->m_command_queue.Get();
+	}
+
+	void CommandQueue::Flush(Fence fence)
+	{
+		fence.Advance();
+		fence.Signal(*this);
+		fence.WaitForFence();
 	}
 
 	CommandQueue::CommandQueue(CommandQueueType type): Type(type), m_command_queue_type()

--- a/DX_Renderer/Core/Components/Command Queue/CommandQueue.cpp
+++ b/DX_Renderer/Core/Components/Command Queue/CommandQueue.cpp
@@ -6,4 +6,9 @@ namespace DXR
 	{
 		return this->m_command_queue.Get();
 	}
+
+	ID3D12CommandQueue* CommandQueue::GetCommandQueueRawPtr()
+	{
+		return this->m_command_queue.Get();
+	}
 }

--- a/DX_Renderer/Core/Components/Command Queue/CommandQueue.cpp
+++ b/DX_Renderer/Core/Components/Command Queue/CommandQueue.cpp
@@ -1,0 +1,9 @@
+#include "CommandQueue.hpp"
+
+namespace DXR 
+{
+	ID3D12CommandQueue* CommandQueue::operator->()
+	{
+		return this->m_command_queue.Get();
+	}
+}

--- a/DX_Renderer/Core/Components/Command Queue/CommandQueue.cpp
+++ b/DX_Renderer/Core/Components/Command Queue/CommandQueue.cpp
@@ -11,4 +11,8 @@ namespace DXR
 	{
 		return this->m_command_queue.Get();
 	}
+
+	CommandQueue::CommandQueue(CommandQueueType type): Type(type), m_command_queue_type()
+	{
+	}
 }

--- a/DX_Renderer/Core/Components/Command Queue/CommandQueue.hpp
+++ b/DX_Renderer/Core/Components/Command Queue/CommandQueue.hpp
@@ -27,7 +27,7 @@ namespace DXR
 		ID3D12CommandQueue* operator->();
 		ID3D12CommandQueue* GetCommandQueueRawPtr();
 	protected:
-		CommandQueue(CommandQueueType type): Type(type), m_command_queue_type(){};
+		CommandQueue(CommandQueueType type);;
 		
 	};
 }

--- a/DX_Renderer/Core/Components/Command Queue/CommandQueue.hpp
+++ b/DX_Renderer/Core/Components/Command Queue/CommandQueue.hpp
@@ -23,9 +23,11 @@ namespace DXR
 		D3D12_COMMAND_LIST_TYPE m_command_queue_type;
 		WRL::ComPtr<ID3D12CommandQueue> m_command_queue;
 	public:
-		CommandQueue(CommandQueueType type):Type(type) {};
 		virtual ~CommandQueue(){};
 		ID3D12CommandQueue* operator->();
 		ID3D12CommandQueue* GetCommandQueueRawPtr();
+	protected:
+		CommandQueue(CommandQueueType type): Type(type), m_command_queue_type(){};
+		
 	};
 }

--- a/DX_Renderer/Core/Components/Command Queue/CommandQueue.hpp
+++ b/DX_Renderer/Core/Components/Command Queue/CommandQueue.hpp
@@ -5,6 +5,7 @@
 
 namespace DXR
 {
+	struct Fence;
 	using namespace Microsoft;
 
 	enum class CommandQueueType
@@ -26,6 +27,7 @@ namespace DXR
 		virtual ~CommandQueue(){};
 		ID3D12CommandQueue* operator->();
 		ID3D12CommandQueue* GetCommandQueueRawPtr();
+		void Flush(Fence fence);
 	protected:
 		CommandQueue(CommandQueueType type);;
 		

--- a/DX_Renderer/Core/Components/Command Queue/CommandQueue.hpp
+++ b/DX_Renderer/Core/Components/Command Queue/CommandQueue.hpp
@@ -26,5 +26,6 @@ namespace DXR
 		CommandQueue(CommandQueueType type):Type(type) {};
 		virtual ~CommandQueue(){};
 		ID3D12CommandQueue* operator->();
+		ID3D12CommandQueue* GetCommandQueueRawPtr();
 	};
 }

--- a/DX_Renderer/Core/Components/Command Queue/CommandQueue.hpp
+++ b/DX_Renderer/Core/Components/Command Queue/CommandQueue.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <wrl.h>
+#include <d3d12.h>
+
+namespace DXR
+{
+	using namespace Microsoft;
+
+	enum class CommandQueueType
+	{
+		None,
+		Direct,
+		Bundle,
+		Compute
+	};
+
+	struct CommandQueue
+	{
+	public:
+		const CommandQueueType Type;
+	protected:
+		D3D12_COMMAND_LIST_TYPE m_command_queue_type;
+		WRL::ComPtr<ID3D12CommandQueue> m_command_queue;
+	public:
+		CommandQueue(CommandQueueType type):Type(type) {};
+		virtual ~CommandQueue(){};
+		ID3D12CommandQueue* operator->();
+	};
+}

--- a/DX_Renderer/Core/Components/Command Queue/GraphicsCommandQueue.cpp
+++ b/DX_Renderer/Core/Components/Command Queue/GraphicsCommandQueue.cpp
@@ -4,8 +4,7 @@
 
 namespace DXR
 {
-	GraphicsCommandQueue::GraphicsCommandQueue(GraphicsDevice& device)
-		:CommandQueue(CommandQueueType::Direct)
+	GraphicsCommandQueue::GraphicsCommandQueue(GraphicsDevice& device):CommandQueue(CommandQueueType::Direct)
 	{
 		this->m_command_queue_type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 		this->CreateCommandQueue(device);

--- a/DX_Renderer/Core/Components/Command Queue/GraphicsCommandQueue.cpp
+++ b/DX_Renderer/Core/Components/Command Queue/GraphicsCommandQueue.cpp
@@ -15,6 +15,8 @@ namespace DXR
 		D3D12_COMMAND_QUEUE_DESC command_queue_description = {};
 		command_queue_description.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
 		command_queue_description.Type = this->m_command_queue_type;
+		INFO_LOG(L"Creating Command Queue\n");
 		DXCall(device->CreateCommandQueue(&command_queue_description, IID_PPV_ARGS(&this->m_command_queue)));
+		SUCCESS_LOG(L"Command Queue Created'n");
 	}
 }

--- a/DX_Renderer/Core/Components/Command Queue/GraphicsCommandQueue.cpp
+++ b/DX_Renderer/Core/Components/Command Queue/GraphicsCommandQueue.cpp
@@ -6,7 +6,7 @@ namespace DXR
 {
 	GraphicsCommandQueue::GraphicsCommandQueue(GraphicsDevice& device):CommandQueue(CommandQueueType::Direct)
 	{
-		this->m_command_queue_type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+		this->m_command_queue_type = D3D12_COMMAND_LIST_TYPE::D3D12_COMMAND_LIST_TYPE_DIRECT;
 		this->CreateCommandQueue(device);
 	}
 

--- a/DX_Renderer/Core/Components/Command Queue/GraphicsCommandQueue.cpp
+++ b/DX_Renderer/Core/Components/Command Queue/GraphicsCommandQueue.cpp
@@ -1,0 +1,21 @@
+#include "GraphicsCommandQueue.hpp"
+
+#include "../../../Tooling/Validate.hpp"
+
+namespace DXR
+{
+	GraphicsCommandQueue::GraphicsCommandQueue(GraphicsDevice& device)
+		:CommandQueue(CommandQueueType::Direct)
+	{
+		this->m_command_queue_type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+		this->CreateCommandQueue(device);
+	}
+
+	inline void GraphicsCommandQueue::CreateCommandQueue(GraphicsDevice& device)
+	{
+		D3D12_COMMAND_QUEUE_DESC command_queue_description = {};
+		command_queue_description.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+		command_queue_description.Type = this->m_command_queue_type;
+		DXCall(device->CreateCommandQueue(&command_queue_description, IID_PPV_ARGS(&this->m_command_queue)));
+	}
+}

--- a/DX_Renderer/Core/Components/Command Queue/GraphicsCommandQueue.hpp
+++ b/DX_Renderer/Core/Components/Command Queue/GraphicsCommandQueue.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "CommandQueue.hpp"
+#include "../GraphicsDevice.hpp"
+
+namespace DXR
+{
+	struct GraphicsCommandQueue: public CommandQueue
+	{
+	public:
+		GraphicsCommandQueue(GraphicsDevice& device);
+	private:
+		inline void CreateCommandQueue(GraphicsDevice& device);
+	};
+}

--- a/DX_Renderer/Core/Components/Command Queue/GraphicsCommandQueue.hpp
+++ b/DX_Renderer/Core/Components/Command Queue/GraphicsCommandQueue.hpp
@@ -8,8 +8,9 @@ namespace DXR
 	struct GraphicsCommandQueue: public CommandQueue
 	{
 	public:
-		GraphicsCommandQueue(GraphicsDevice& device);
+		friend GraphicsDevice;
 	private:
+		GraphicsCommandQueue(GraphicsDevice& device);
 		inline void CreateCommandQueue(GraphicsDevice& device);
 	};
 }

--- a/DX_Renderer/Core/Components/Fence.cpp
+++ b/DX_Renderer/Core/Components/Fence.cpp
@@ -8,6 +8,8 @@ namespace DXR
 	{
 		this->initial_value = initialValue;
 		this->current_value = current_value;
+		INFO_LOG(L"Creting Fence\n");
 		DXCall(device->CreateFence(initialValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&this->m_fence)));
+		SUCCESS_LOG(L"Fence Created\n");
 	}
 }

--- a/DX_Renderer/Core/Components/Fence.cpp
+++ b/DX_Renderer/Core/Components/Fence.cpp
@@ -1,0 +1,13 @@
+#include "Fence.hpp"
+#include "GraphicsDevice.hpp"
+#include "../../Tooling/Validate.hpp"
+
+namespace DXR
+{
+	Fence::Fence(UINT64 initialValue, GraphicsDevice& device)
+	{
+		this->initial_value = initialValue;
+		this->current_value = current_value;
+		DXCall(device->CreateFence(initialValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&this->m_fence)));
+	}
+}

--- a/DX_Renderer/Core/Components/Fence.cpp
+++ b/DX_Renderer/Core/Components/Fence.cpp
@@ -12,4 +12,35 @@ namespace DXR
 		DXCall(device->CreateFence(initialValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&this->m_fence)));
 		SUCCESS_LOG(L"Fence Created\n");
 	}
+
+	void Fence::Advance()
+	{
+		this->current_value++;
+		INFO_LOG(L"Fence Value Advaned\n");
+	}
+
+	void Fence::Signal(CommandQueue& queue) const
+	{
+		INFO_LOG(L"Attempting To Signal Fence\n");
+		DXCall(queue->Signal(this->m_fence.Get(),this->current_value));
+		SUCCESS_LOG(L"Fence Signaled\n");
+	}
+
+	UINT64 Fence::GetCompletedValue() const
+	{
+		return this->m_fence->GetCompletedValue();
+	}
+
+	void Fence::WaitForFence() const
+	{
+		INFO_LOG(L"Started Waring On Fence\n");
+		if(this->GetCompletedValue()<this->current_value)
+		{
+			HANDLE eventHandle = CreateEventEx(nullptr,false,false,EVENT_ALL_ACCESS);
+			this->m_fence->SetEventOnCompletion(current_value,eventHandle);
+			WaitForSingleObject(eventHandle,INFINITE);
+			CloseHandle(eventHandle);
+		}
+		SUCCESS_LOG(L"Finished Waiting On Fence\n");
+	}
 }

--- a/DX_Renderer/Core/Components/Fence.hpp
+++ b/DX_Renderer/Core/Components/Fence.hpp
@@ -5,6 +5,7 @@
 
 namespace DXR
 {
+	struct CommandQueue;
 	using namespace Microsoft;
 
 	struct GraphicsDevice;
@@ -19,6 +20,10 @@ namespace DXR
 		WRL::ComPtr<ID3D12Fence> m_fence;
 	public:
 		Fence(UINT64 initialValue,GraphicsDevice& device);
+		void Advance();
+		void Signal(CommandQueue& queue) const;
+		UINT64 GetCompletedValue() const;
+		void WaitForFence() const;
 	private:
 	};
 }

--- a/DX_Renderer/Core/Components/Fence.hpp
+++ b/DX_Renderer/Core/Components/Fence.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <d3d12.h>
+#include <wrl.h>
+
+namespace DXR
+{
+	using namespace Microsoft;
+
+	struct GraphicsDevice;
+
+	struct Fence
+	{
+	public:
+		friend GraphicsDevice;
+		UINT64 initial_value = 0;
+	private:
+		UINT64 current_value = 0;
+		WRL::ComPtr<ID3D12Fence> m_fence;
+	public:
+		Fence(UINT64 initialValue,GraphicsDevice& device);
+	private:
+	};
+}

--- a/DX_Renderer/Core/Components/GraphicsDevice.cpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.cpp
@@ -5,11 +5,18 @@ namespace DXR
 	GraphicsDevice::GraphicsDevice()
 	{
 		this->CreateDXGIFactory();
+		this->CreateDefaultD3D12Device();
 	}
 
 	void GraphicsDevice::CreateDXGIFactory()
 	{
 		::CreateDXGIFactory(IID_PPV_ARGS(&this->m_dxgi_factory));
+	}
+
+	void GraphicsDevice::CreateDefaultD3D12Device()
+	{
+		// TODO(Tiago): Handle the result from the creation to check if it created the device successfully
+		HRESULT result = D3D12CreateDevice(nullptr, this->m_minimum_feature_level, IID_PPV_ARGS(&this->m_device));
 	}
 
 	std::vector<WRL::ComPtr<IDXGIAdapter>> GraphicsDevice::GetGraphicsAdapterList() const

--- a/DX_Renderer/Core/Components/GraphicsDevice.cpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.cpp
@@ -67,18 +67,24 @@ namespace DXR
 
 	void GraphicsDevice::CreateDXGIFactory()
 	{
+		INFO_LOG(L"Creating DXGI Factory\n");
 		DXCall(::CreateDXGIFactory(IID_PPV_ARGS(&this->m_dxgi_factory)));
+		SUCCESS_LOG(L"DXGI Factory Created\n");
 	}
 
 	void GraphicsDevice::CreateDefaultD3D12Device()
 	{
+		INFO_LOG(L"Creating Default D3D12 Device\n");
 		DXCall(D3D12CreateDevice(nullptr, this->m_minimum_feature_level, IID_PPV_ARGS(&this->m_device)));
+		SUCCESS_LOG(L"Default D3D12 Device Created\n");
 	}
 
 	void GraphicsDevice::CreateD3D12Device(UINT8 deviceIndex)
 	{
 		auto adapter_list = this->GetGraphicsAdapterList();
+		INFO_LOG(L"Creating D3D12 Device\n");
 		DXCall(D3D12CreateDevice(adapter_list[deviceIndex].Get(), this->m_minimum_feature_level, IID_PPV_ARGS(&this->m_device)));
+		SUCCESS_LOG(L"D3D12 Device Created\n");
 	}
 
 	std::vector<WRL::ComPtr<IDXGIAdapter>> GraphicsDevice::GetGraphicsAdapterList() const

--- a/DX_Renderer/Core/Components/GraphicsDevice.cpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.cpp
@@ -8,6 +8,12 @@ namespace DXR
 		this->CreateDefaultD3D12Device();
 	}
 
+	GraphicsDevice::GraphicsDevice(UINT8 DeviceIndex)
+	{
+		this->CreateDXGIFactory();
+		this->CreateD3D12Device(DeviceIndex);
+	}
+
 	void GraphicsDevice::CreateDXGIFactory()
 	{
 		::CreateDXGIFactory(IID_PPV_ARGS(&this->m_dxgi_factory));
@@ -17,6 +23,13 @@ namespace DXR
 	{
 		// TODO(Tiago): Handle the result from the creation to check if it created the device successfully
 		HRESULT result = D3D12CreateDevice(nullptr, this->m_minimum_feature_level, IID_PPV_ARGS(&this->m_device));
+	}
+
+	void GraphicsDevice::CreateD3D12Device(UINT8 deviceIndex)
+	{
+		auto adapter_list = this->GetGraphicsAdapterList();
+		// TODO(Tiago): Handle the result from the creation to check if it created the device successfully
+		HRESULT result = D3D12CreateDevice(adapter_list[deviceIndex].Get(),this->m_minimum_feature_level, IID_PPV_ARGS(&this->m_device));
 	}
 
 	std::vector<WRL::ComPtr<IDXGIAdapter>> GraphicsDevice::GetGraphicsAdapterList() const

--- a/DX_Renderer/Core/Components/GraphicsDevice.cpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.cpp
@@ -2,6 +2,8 @@
 #include "../../Tooling/Validate.hpp"
 #include "Fence.hpp"
 #include "Command Queue/GraphicsCommandQueue.hpp"
+#include "Command List/GraphicsCommandList.hpp"
+#include "Swapchain.hpp"
 
 namespace DXR
 {
@@ -35,6 +37,17 @@ namespace DXR
 	{
 		return Fence(initialValue, *this);
 	}
+
+	GraphicsCommandList GraphicsDevice::CreateGraphicsCommandList()
+	{
+		return GraphicsCommandList(*this);
+	}
+
+	Swapchain GraphicsDevice::CreateSwapchain(Window& window, UINT refreshRate)
+	{
+		return Swapchain(*this,window,refreshRate);
+	}
+
 
 	void GraphicsDevice::CreateDXGIFactory()
 	{
@@ -90,7 +103,7 @@ namespace DXR
 	{
 		this->m_graphics_command_queue = new GraphicsCommandQueue(*this);
 	}
-	
+
 	void GraphicsDevice::CheckSupportedMSAALevels(DXGI_FORMAT backbufferFormat)
 	{
 		this->supported_mssa_levels.clear();

--- a/DX_Renderer/Core/Components/GraphicsDevice.cpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.cpp
@@ -93,6 +93,7 @@ namespace DXR
 	
 	void GraphicsDevice::CheckSupportedMSAALevels(DXGI_FORMAT backbufferFormat)
 	{
+		this->supported_mssa_levels.clear();
 		D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS quality_levels = {};
 		quality_levels.Format = backbufferFormat;
 		quality_levels.Flags = D3D12_MULTISAMPLE_QUALITY_LEVELS_FLAG_NONE;

--- a/DX_Renderer/Core/Components/GraphicsDevice.cpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.cpp
@@ -23,12 +23,12 @@ namespace DXR
 		this->CreateGraphicsCommandQueue();
 	}
 
-	ID3D12Device* GraphicsDevice::operator->()
+	ID3D12Device* GraphicsDevice::operator->() const
 	{
 		return this->m_device.Get();
 	}
 
-	IDXGIFactory* GraphicsDevice::GetDXGIFactory()
+	IDXGIFactory* GraphicsDevice::GetDXGIFactory() const
 	{
 		return this->m_dxgi_factory.Get();
 	}
@@ -87,14 +87,14 @@ namespace DXR
 
 	void GraphicsDevice::QueryAllDescriptorSizes()
 	{
-		const UINT64 RTV_size = this->QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-		const UINT64 CBV_SRV_UAV_size = this->QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-		const UINT64 DSV_size = this->QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE_DSV);
-		const UINT64 Sampler_size = this->QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
+		const UINT64 RTV_size = this->QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE::D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		const UINT64 CBV_SRV_UAV_size = this->QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE::D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+		const UINT64 DSV_size = this->QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE::D3D12_DESCRIPTOR_HEAP_TYPE_DSV);
+		const UINT64 Sampler_size = this->QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE::D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
 		this->descriptorSizes = {RTV_size,CBV_SRV_UAV_size,DSV_size,Sampler_size};
 	}
 
-	UINT64 GraphicsDevice::QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE descriptorType)
+	UINT64 GraphicsDevice::QueryDescriptorSize(enum D3D12_DESCRIPTOR_HEAP_TYPE descriptorType) const
 	{
 		return this->m_device->GetDescriptorHandleIncrementSize(descriptorType);
 	}

--- a/DX_Renderer/Core/Components/GraphicsDevice.cpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.cpp
@@ -33,6 +33,11 @@ namespace DXR
 		return this->m_dxgi_factory.Get();
 	}
 
+	DescriptorSizes GraphicsDevice::GetDescriptorSizes() const
+	{
+		return this->descriptorSizes;
+	}
+
 	Fence GraphicsDevice::CreateFence(UINT64 initialValue)
 	{
 		return Fence(initialValue, *this);

--- a/DX_Renderer/Core/Components/GraphicsDevice.cpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.cpp
@@ -59,6 +59,11 @@ namespace DXR
 		return DescriptorHeap(*this,descriptorCount,DescriptorType::RenderTargetView);
 	}
 
+	DescriptorHeap GraphicsDevice::CreateDepthStencilBufferDescriptorHeap(const UINT descriptorCount)
+	{
+		return DescriptorHeap(*this,descriptorCount,DescriptorType::DepthStencilBuffer);
+	}
+
 
 	void GraphicsDevice::CreateDXGIFactory()
 	{

--- a/DX_Renderer/Core/Components/GraphicsDevice.cpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.cpp
@@ -8,12 +8,14 @@ namespace DXR
 	{
 		this->CreateDXGIFactory();
 		this->CreateDefaultD3D12Device();
+		this->QueryAllDescriptorSizes();
 	}
 
 	GraphicsDevice::GraphicsDevice(UINT8 DeviceIndex)
 	{
 		this->CreateDXGIFactory();
 		this->CreateD3D12Device(DeviceIndex);
+		this->QueryAllDescriptorSizes();
 	}
 
 	ID3D12Device* GraphicsDevice::operator->()
@@ -23,7 +25,7 @@ namespace DXR
 
 	Fence GraphicsDevice::CreateFence(UINT64 initialValue)
 	{
-		return Fence(initialValue,*this);
+		return Fence(initialValue, *this);
 	}
 
 	void GraphicsDevice::CreateDXGIFactory()
@@ -39,7 +41,7 @@ namespace DXR
 	void GraphicsDevice::CreateD3D12Device(UINT8 deviceIndex)
 	{
 		auto adapter_list = this->GetGraphicsAdapterList();
-		DXCall(D3D12CreateDevice(adapter_list[deviceIndex].Get(),this->m_minimum_feature_level, IID_PPV_ARGS(&this->m_device)));
+		DXCall(D3D12CreateDevice(adapter_list[deviceIndex].Get(), this->m_minimum_feature_level, IID_PPV_ARGS(&this->m_device)));
 	}
 
 	std::vector<WRL::ComPtr<IDXGIAdapter>> GraphicsDevice::GetGraphicsAdapterList() const
@@ -47,7 +49,7 @@ namespace DXR
 		std::vector<WRL::ComPtr<IDXGIAdapter>> adapter_list;
 		UINT8 adapter_index = 0;
 		IDXGIAdapter* current_adapter = nullptr;
-		while(m_dxgi_factory->EnumAdapters(adapter_index,&current_adapter) != DXGI_ERROR_NOT_FOUND)
+		while(m_dxgi_factory->EnumAdapters(adapter_index, &current_adapter) != DXGI_ERROR_NOT_FOUND)
 		{
 			adapter_list.emplace_back(current_adapter);
 
@@ -56,9 +58,23 @@ namespace DXR
 				current_adapter->Release();
 				current_adapter = nullptr;
 			}
-			
+
 			++adapter_index;
 		}
 		return adapter_list;
+	}
+
+	void GraphicsDevice::QueryAllDescriptorSizes()
+	{
+		const UINT64 RTV_size = this->QueryDescriptoSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		const UINT64 CBV_SRV_UAV_size = this->QueryDescriptoSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+		const UINT64 DSV_size = this->QueryDescriptoSize(D3D12_DESCRIPTOR_HEAP_TYPE_DSV);
+		const UINT64 Sampler_size = this->QueryDescriptoSize(D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
+		this->descriptorSizes = {RTV_size,CBV_SRV_UAV_size,DSV_size,Sampler_size};
+	}
+
+	UINT64 GraphicsDevice::QueryDescriptoSize(D3D12_DESCRIPTOR_HEAP_TYPE descriptorType)
+	{
+		return this->m_device->GetDescriptorHandleIncrementSize(descriptorType);
 	}
 }

--- a/DX_Renderer/Core/Components/GraphicsDevice.cpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.cpp
@@ -4,6 +4,7 @@
 #include "Command Queue/GraphicsCommandQueue.hpp"
 #include "Command List/GraphicsCommandList.hpp"
 #include "Swapchain.hpp"
+#include "Resource/DescriptorHeap.hpp"
 
 namespace DXR
 {
@@ -51,6 +52,11 @@ namespace DXR
 	Swapchain GraphicsDevice::CreateSwapchain(Window& window, UINT refreshRate)
 	{
 		return Swapchain(*this,window,refreshRate);
+	}
+
+	DescriptorHeap GraphicsDevice::CreateRenderTargetViewDescriptorHeap(const UINT descriptorCount)
+	{
+		return DescriptorHeap(*this,descriptorCount,DescriptorType::RenderTargetView);
 	}
 
 

--- a/DX_Renderer/Core/Components/GraphicsDevice.cpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.cpp
@@ -42,7 +42,7 @@ namespace DXR
 			adapter_list.emplace_back(current_adapter);
 
 			{
-				// to prevent leaks we must release the adapter interface when we no longer need;
+				// to prevent leaks we must release the adapter interface when we no longer need it
 				current_adapter->Release();
 				current_adapter = nullptr;
 			}

--- a/DX_Renderer/Core/Components/GraphicsDevice.cpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.cpp
@@ -1,0 +1,34 @@
+#include "GraphicsDevice.hpp"
+
+namespace DXR
+{
+	GraphicsDevice::GraphicsDevice()
+	{
+		this->CreateDXGIFactory();
+	}
+
+	void GraphicsDevice::CreateDXGIFactory()
+	{
+		::CreateDXGIFactory(IID_PPV_ARGS(&this->m_dxgi_factory));
+	}
+
+	std::vector<WRL::ComPtr<IDXGIAdapter>> GraphicsDevice::GetGraphicsAdapterList() const
+	{
+		std::vector<WRL::ComPtr<IDXGIAdapter>> adapter_list;
+		UINT8 adapter_index = 1;
+		IDXGIAdapter* current_adapter = nullptr;
+		while(m_dxgi_factory->EnumAdapters(adapter_index,&current_adapter) != DXGI_ERROR_NOT_FOUND)
+		{
+			adapter_list.emplace_back(current_adapter);
+
+			{
+				// to prevent leaks we must release the adapter interface when we no longer need;
+				current_adapter->Release();
+				current_adapter = nullptr;
+			}
+			
+			++adapter_index;
+		}
+		return adapter_list;
+	}
+}

--- a/DX_Renderer/Core/Components/GraphicsDevice.cpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.cpp
@@ -15,7 +15,7 @@ namespace DXR
 	std::vector<WRL::ComPtr<IDXGIAdapter>> GraphicsDevice::GetGraphicsAdapterList() const
 	{
 		std::vector<WRL::ComPtr<IDXGIAdapter>> adapter_list;
-		UINT8 adapter_index = 1;
+		UINT8 adapter_index = 0;
 		IDXGIAdapter* current_adapter = nullptr;
 		while(m_dxgi_factory->EnumAdapters(adapter_index,&current_adapter) != DXGI_ERROR_NOT_FOUND)
 		{

--- a/DX_Renderer/Core/Components/GraphicsDevice.cpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.cpp
@@ -66,15 +66,35 @@ namespace DXR
 
 	void GraphicsDevice::QueryAllDescriptorSizes()
 	{
-		const UINT64 RTV_size = this->QueryDescriptoSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-		const UINT64 CBV_SRV_UAV_size = this->QueryDescriptoSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-		const UINT64 DSV_size = this->QueryDescriptoSize(D3D12_DESCRIPTOR_HEAP_TYPE_DSV);
-		const UINT64 Sampler_size = this->QueryDescriptoSize(D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
+		const UINT64 RTV_size = this->QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+		const UINT64 CBV_SRV_UAV_size = this->QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+		const UINT64 DSV_size = this->QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE_DSV);
+		const UINT64 Sampler_size = this->QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
 		this->descriptorSizes = {RTV_size,CBV_SRV_UAV_size,DSV_size,Sampler_size};
 	}
 
-	UINT64 GraphicsDevice::QueryDescriptoSize(D3D12_DESCRIPTOR_HEAP_TYPE descriptorType)
+	UINT64 GraphicsDevice::QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE descriptorType)
 	{
 		return this->m_device->GetDescriptorHandleIncrementSize(descriptorType);
+	}
+	
+	void GraphicsDevice::CheckSupportedMSAALevels(DXGI_FORMAT backbufferFormat)
+	{
+		D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS quality_levels = {};
+		quality_levels.Format = backbufferFormat;
+		quality_levels.Flags = D3D12_MULTISAMPLE_QUALITY_LEVELS_FLAG_NONE;
+		quality_levels.SampleCount = 1;
+		bool continueSupportCheck = true;
+		while(continueSupportCheck)
+		{
+			DXCall(this->m_device->CheckFeatureSupport(D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS, &quality_levels, sizeof(quality_levels)));
+			if(quality_levels.NumQualityLevels > 0)
+			{
+				this->supported_mssa_levels.emplace_back(quality_levels.SampleCount);
+				quality_levels.SampleCount *= 2;
+			} else {
+				continueSupportCheck = false;
+			}
+		}
 	}
 }

--- a/DX_Renderer/Core/Components/GraphicsDevice.cpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.cpp
@@ -1,5 +1,6 @@
 #include "GraphicsDevice.hpp"
 #include "../../Tooling/Validate.hpp"
+#include "Fence.hpp"
 
 namespace DXR
 {
@@ -13,6 +14,16 @@ namespace DXR
 	{
 		this->CreateDXGIFactory();
 		this->CreateD3D12Device(DeviceIndex);
+	}
+
+	ID3D12Device* GraphicsDevice::operator->()
+	{
+		return this->m_device.Get();
+	}
+
+	Fence GraphicsDevice::CreateFence(UINT64 initialValue)
+	{
+		return Fence(initialValue,*this);
 	}
 
 	void GraphicsDevice::CreateDXGIFactory()

--- a/DX_Renderer/Core/Components/GraphicsDevice.cpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.cpp
@@ -49,19 +49,19 @@ namespace DXR
 		return GraphicsCommandList(*this);
 	}
 
-	Swapchain GraphicsDevice::CreateSwapchain(Window& window, UINT refreshRate)
+	Swapchain GraphicsDevice::CreateSwapchain(Window& window, UINT refreshRate, GraphicsCommandList& commandList)
 	{
-		return Swapchain(*this,window,refreshRate);
+		return Swapchain(*this, window, refreshRate, commandList);
 	}
 
 	DescriptorHeap GraphicsDevice::CreateRenderTargetViewDescriptorHeap(const UINT descriptorCount)
 	{
-		return DescriptorHeap(*this,descriptorCount,DescriptorType::RenderTargetView);
+		return DescriptorHeap(*this, descriptorCount, DescriptorType::RenderTargetView);
 	}
 
 	DescriptorHeap GraphicsDevice::CreateDepthStencilBufferDescriptorHeap(const UINT descriptorCount)
 	{
-		return DescriptorHeap(*this,descriptorCount,DescriptorType::DepthStencilBuffer);
+		return DescriptorHeap(*this, descriptorCount, DescriptorType::DepthStencilBuffer);
 	}
 
 

--- a/DX_Renderer/Core/Components/GraphicsDevice.cpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.cpp
@@ -1,4 +1,5 @@
 #include "GraphicsDevice.hpp"
+#include "../../Tooling/Validate.hpp"
 
 namespace DXR
 {
@@ -21,15 +22,13 @@ namespace DXR
 
 	void GraphicsDevice::CreateDefaultD3D12Device()
 	{
-		// TODO(Tiago): Handle the result from the creation to check if it created the device successfully
-		HRESULT result = D3D12CreateDevice(nullptr, this->m_minimum_feature_level, IID_PPV_ARGS(&this->m_device));
+		DXCall(D3D12CreateDevice(nullptr, this->m_minimum_feature_level, IID_PPV_ARGS(&this->m_device)));
 	}
 
 	void GraphicsDevice::CreateD3D12Device(UINT8 deviceIndex)
 	{
 		auto adapter_list = this->GetGraphicsAdapterList();
-		// TODO(Tiago): Handle the result from the creation to check if it created the device successfully
-		HRESULT result = D3D12CreateDevice(adapter_list[deviceIndex].Get(),this->m_minimum_feature_level, IID_PPV_ARGS(&this->m_device));
+		DXCall(D3D12CreateDevice(adapter_list[deviceIndex].Get(),this->m_minimum_feature_level, IID_PPV_ARGS(&this->m_device)));
 	}
 
 	std::vector<WRL::ComPtr<IDXGIAdapter>> GraphicsDevice::GetGraphicsAdapterList() const

--- a/DX_Renderer/Core/Components/GraphicsDevice.cpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.cpp
@@ -89,6 +89,7 @@ namespace DXR
 
 	std::vector<WRL::ComPtr<IDXGIAdapter>> GraphicsDevice::GetGraphicsAdapterList() const
 	{
+		INFO_LOG(L"Fetching Complete Adapter List\n");
 		std::vector<WRL::ComPtr<IDXGIAdapter>> adapter_list;
 		UINT8 adapter_index = 0;
 		IDXGIAdapter* current_adapter = nullptr;
@@ -104,16 +105,19 @@ namespace DXR
 
 			++adapter_index;
 		}
+		INFO_LOG(L"Finished Fetching Complete Adapter List\n");
 		return adapter_list;
 	}
 
 	void GraphicsDevice::QueryAllDescriptorSizes()
 	{
+		INFO_LOG(L"Fetching Descriptor Handle Increment Sizes\n");
 		const UINT64 RTV_size = this->QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE::D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
 		const UINT64 CBV_SRV_UAV_size = this->QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE::D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 		const UINT64 DSV_size = this->QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE::D3D12_DESCRIPTOR_HEAP_TYPE_DSV);
 		const UINT64 Sampler_size = this->QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE::D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
 		this->descriptorSizes = {RTV_size,CBV_SRV_UAV_size,DSV_size,Sampler_size};
+		SUCCESS_LOG(L"Finished Fetching Descriptor Handle Increment Sizes\n");
 	}
 
 	UINT64 GraphicsDevice::QueryDescriptorSize(enum D3D12_DESCRIPTOR_HEAP_TYPE descriptorType) const
@@ -128,6 +132,7 @@ namespace DXR
 
 	void GraphicsDevice::CheckSupportedMSAALevels(DXGI_FORMAT backbufferFormat)
 	{
+		INFO_LOG(L"Fetching Supported MSAA Levels\n");
 		this->supported_mssa_levels.clear();
 		D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS quality_levels = {};
 		quality_levels.Format = backbufferFormat;
@@ -145,6 +150,7 @@ namespace DXR
 				continueSupportCheck = false;
 			}
 		}
+		SUCCESS_LOG(L"Finished Fetching Supported MSAA Quality Levels\n");
 	}
 
 	CommandQueue* GraphicsDevice::GetGraphicsCommandQueue()

--- a/DX_Renderer/Core/Components/GraphicsDevice.cpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.cpp
@@ -1,6 +1,7 @@
 #include "GraphicsDevice.hpp"
 #include "../../Tooling/Validate.hpp"
 #include "Fence.hpp"
+#include "Command Queue/GraphicsCommandQueue.hpp"
 
 namespace DXR
 {
@@ -9,6 +10,7 @@ namespace DXR
 		this->CreateDXGIFactory();
 		this->CreateDefaultD3D12Device();
 		this->QueryAllDescriptorSizes();
+		this->CreateGraphicsCommandQueue();
 	}
 
 	GraphicsDevice::GraphicsDevice(UINT8 DeviceIndex)
@@ -16,11 +18,17 @@ namespace DXR
 		this->CreateDXGIFactory();
 		this->CreateD3D12Device(DeviceIndex);
 		this->QueryAllDescriptorSizes();
+		this->CreateGraphicsCommandQueue();
 	}
 
 	ID3D12Device* GraphicsDevice::operator->()
 	{
 		return this->m_device.Get();
+	}
+
+	IDXGIFactory* GraphicsDevice::GetDXGIFactory()
+	{
+		return this->m_dxgi_factory.Get();
 	}
 
 	Fence GraphicsDevice::CreateFence(UINT64 initialValue)
@@ -77,6 +85,11 @@ namespace DXR
 	{
 		return this->m_device->GetDescriptorHandleIncrementSize(descriptorType);
 	}
+
+	inline void GraphicsDevice::CreateGraphicsCommandQueue()
+	{
+		this->m_graphics_command_queue = new GraphicsCommandQueue(*this);
+	}
 	
 	void GraphicsDevice::CheckSupportedMSAALevels(DXGI_FORMAT backbufferFormat)
 	{
@@ -96,5 +109,10 @@ namespace DXR
 				continueSupportCheck = false;
 			}
 		}
+	}
+
+	CommandQueue* GraphicsDevice::GetGraphicsCommandQueue()
+	{
+		return this->m_graphics_command_queue;
 	}
 }

--- a/DX_Renderer/Core/Components/GraphicsDevice.cpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.cpp
@@ -17,7 +17,7 @@ namespace DXR
 
 	void GraphicsDevice::CreateDXGIFactory()
 	{
-		::CreateDXGIFactory(IID_PPV_ARGS(&this->m_dxgi_factory));
+		DXCall(::CreateDXGIFactory(IID_PPV_ARGS(&this->m_dxgi_factory)));
 	}
 
 	void GraphicsDevice::CreateDefaultD3D12Device()

--- a/DX_Renderer/Core/Components/GraphicsDevice.hpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.hpp
@@ -4,7 +4,6 @@
 #include <wrl.h>
 #include <vector>
 #include <d3d12.h>
-#include <memory>
 
 #include "Command Queue/CommandQueue.hpp"
 
@@ -31,17 +30,17 @@ namespace DXR
 	public:
 		std::vector<UINT8> supported_mssa_levels;
 	private:
-		D3D_FEATURE_LEVEL m_minimum_feature_level = D3D_FEATURE_LEVEL_11_0;
+		enum D3D_FEATURE_LEVEL m_minimum_feature_level = D3D_FEATURE_LEVEL::D3D_FEATURE_LEVEL_11_0;
 		WRL::ComPtr<IDXGIFactory> m_dxgi_factory;
 		WRL::ComPtr <ID3D12Device> m_device;
-		DescriptorSizes descriptorSizes;
-		CommandQueue* m_graphics_command_queue;
+		DescriptorSizes descriptorSizes{};
+		CommandQueue* m_graphics_command_queue{};
 	// public and privte methods
 	public:
 		GraphicsDevice();
 		GraphicsDevice(UINT8 DeviceIndex);
-		ID3D12Device* operator->();
-		IDXGIFactory* GetDXGIFactory();
+		ID3D12Device* operator->() const;
+		IDXGIFactory* GetDXGIFactory() const;
 		void CheckSupportedMSAALevels(DXGI_FORMAT backbufferFormat);
 		CommandQueue* GetGraphicsCommandQueue();
 		Fence CreateFence(UINT64 initialValue);
@@ -53,7 +52,7 @@ namespace DXR
 		void CreateD3D12Device(UINT8 deviceIndex);
 		std::vector<WRL::ComPtr<IDXGIAdapter>> GetGraphicsAdapterList() const;
 		void QueryAllDescriptorSizes();
-		UINT64 QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE descriptorType);
+		UINT64 QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE descriptorType) const;
 		inline void CreateGraphicsCommandQueue();
 	};
 }

--- a/DX_Renderer/Core/Components/GraphicsDevice.hpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.hpp
@@ -9,13 +9,15 @@ namespace DXR
 {
 	using namespace Microsoft;
 	
+	struct Fence;
+
 	struct GraphicsDevice
 	{
 	// public and private data fields
 	public:
 		
 	private:
-		D3D_FEATURE_LEVEL m_minimum_feature_level = D3D_FEATURE_LEVEL_11_1;
+		D3D_FEATURE_LEVEL m_minimum_feature_level = D3D_FEATURE_LEVEL_11_0;
 		
 		WRL::ComPtr<IDXGIFactory> m_dxgi_factory;
 		WRL::ComPtr <ID3D12Device> m_device;
@@ -24,6 +26,8 @@ namespace DXR
 	public:
 		GraphicsDevice();
 		GraphicsDevice(UINT8 DeviceIndex);
+		ID3D12Device* operator->();
+		Fence CreateFence(UINT64 initialValue);
 	private:
 		void CreateDXGIFactory();
 		void CreateDefaultD3D12Device();

--- a/DX_Renderer/Core/Components/GraphicsDevice.hpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.hpp
@@ -41,6 +41,7 @@ namespace DXR
 		GraphicsDevice(UINT8 DeviceIndex);
 		ID3D12Device* operator->() const;
 		IDXGIFactory* GetDXGIFactory() const;
+		DescriptorSizes GetDescriptorSizes()const;
 		void CheckSupportedMSAALevels(DXGI_FORMAT backbufferFormat);
 		CommandQueue* GetGraphicsCommandQueue();
 		Fence CreateFence(UINT64 initialValue);

--- a/DX_Renderer/Core/Components/GraphicsDevice.hpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.hpp
@@ -11,7 +11,7 @@ namespace DXR
 {
 	struct Window;
 	using namespace Microsoft;
-	
+
 	struct Fence;
 	struct GraphicsCommandList;
 	struct Swapchain;
@@ -27,7 +27,7 @@ namespace DXR
 
 	struct GraphicsDevice
 	{
-	// public and private data fields
+		// public and private data fields
 	public:
 		std::vector<UINT8> supported_mssa_levels;
 	private:
@@ -36,7 +36,7 @@ namespace DXR
 		WRL::ComPtr <ID3D12Device> m_device;
 		DescriptorSizes descriptorSizes{};
 		CommandQueue* m_graphics_command_queue{};
-	// public and privte methods
+		// public and privte methods
 	public:
 		GraphicsDevice();
 		GraphicsDevice(UINT8 DeviceIndex);
@@ -47,7 +47,7 @@ namespace DXR
 		CommandQueue* GetGraphicsCommandQueue();
 		Fence CreateFence(UINT64 initialValue);
 		GraphicsCommandList CreateGraphicsCommandList();
-		Swapchain CreateSwapchain(Window& window, UINT refreshRate);
+		Swapchain CreateSwapchain(Window& window, UINT refreshRate, GraphicsCommandList& commandList);
 		DescriptorHeap CreateRenderTargetViewDescriptorHeap(const UINT descriptorCount);
 		DescriptorHeap CreateDepthStencilBufferDescriptorHeap(const UINT descriptorCount);
 	private:

--- a/DX_Renderer/Core/Components/GraphicsDevice.hpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.hpp
@@ -15,7 +15,7 @@ namespace DXR
 	public:
 		
 	private:
-		D3D_FEATURE_LEVEL m_minimum_feature_level = D3D_FEATURE_LEVEL_11_0;
+		D3D_FEATURE_LEVEL m_minimum_feature_level = D3D_FEATURE_LEVEL_11_1;
 		
 		WRL::ComPtr<IDXGIFactory> m_dxgi_factory;
 		WRL::ComPtr <ID3D12Device> m_device;

--- a/DX_Renderer/Core/Components/GraphicsDevice.hpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.hpp
@@ -3,6 +3,7 @@
 #include <dxgi.h>
 #include <wrl.h>
 #include <vector>
+#include <d3d12.h>
 
 namespace DXR
 {
@@ -10,18 +11,22 @@ namespace DXR
 	
 	struct GraphicsDevice
 	{
-	//
+	// public and private data fields
 	public:
 		
 	private:
+		D3D_FEATURE_LEVEL m_minimum_feature_level = D3D_FEATURE_LEVEL_11_0;
+		
 		WRL::ComPtr<IDXGIFactory> m_dxgi_factory;
-	//
+		WRL::ComPtr <ID3D12Device> m_device;
+
+	// public and privte methods
 	public:
 		GraphicsDevice();
 		GraphicsDevice(UINT8 DeviceIndex);
-		std::vector<WRL::ComPtr<IDXGIAdapter>> GetGraphicsAdapterList() const;
 	private:
 		void CreateDXGIFactory();
-		
+		std::vector<WRL::ComPtr<IDXGIAdapter>> GetGraphicsAdapterList() const;
+		void CreateDefaultD3D12Device();
 	};
 }

--- a/DX_Renderer/Core/Components/GraphicsDevice.hpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.hpp
@@ -15,6 +15,7 @@ namespace DXR
 	struct Fence;
 	struct GraphicsCommandList;
 	struct Swapchain;
+	struct DescriptorHeap;
 
 	struct DescriptorSizes
 	{
@@ -47,6 +48,7 @@ namespace DXR
 		Fence CreateFence(UINT64 initialValue);
 		GraphicsCommandList CreateGraphicsCommandList();
 		Swapchain CreateSwapchain(Window& window, UINT refreshRate);
+		DescriptorHeap CreateRenderTargetViewDescriptorHeap(const UINT descriptorCount);
 	private:
 		void CreateDXGIFactory();
 		void CreateDefaultD3D12Device();

--- a/DX_Renderer/Core/Components/GraphicsDevice.hpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.hpp
@@ -4,6 +4,9 @@
 #include <wrl.h>
 #include <vector>
 #include <d3d12.h>
+#include <memory>
+
+#include "Command Queue/CommandQueue.hpp"
 
 namespace DXR
 {
@@ -26,19 +29,19 @@ namespace DXR
 		std::vector<UINT8> supported_mssa_levels;
 	private:
 		D3D_FEATURE_LEVEL m_minimum_feature_level = D3D_FEATURE_LEVEL_11_0;
-		
 		WRL::ComPtr<IDXGIFactory> m_dxgi_factory;
 		WRL::ComPtr <ID3D12Device> m_device;
-
 		DescriptorSizes descriptorSizes;
-
+		CommandQueue* m_graphics_command_queue;
 	// public and privte methods
 	public:
 		GraphicsDevice();
 		GraphicsDevice(UINT8 DeviceIndex);
 		ID3D12Device* operator->();
+		IDXGIFactory* GetDXGIFactory();
 		Fence CreateFence(UINT64 initialValue);
 		void CheckSupportedMSAALevels(DXGI_FORMAT backbufferFormat);
+		CommandQueue* GetGraphicsCommandQueue();
 	private:
 		void CreateDXGIFactory();
 		void CreateDefaultD3D12Device();
@@ -46,5 +49,6 @@ namespace DXR
 		std::vector<WRL::ComPtr<IDXGIAdapter>> GetGraphicsAdapterList() const;
 		void QueryAllDescriptorSizes();
 		UINT64 QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE descriptorType);
+		inline void CreateGraphicsCommandQueue();
 	};
 }

--- a/DX_Renderer/Core/Components/GraphicsDevice.hpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.hpp
@@ -10,9 +10,12 @@
 
 namespace DXR
 {
+	struct Window;
 	using namespace Microsoft;
 	
 	struct Fence;
+	struct GraphicsCommandList;
+	struct Swapchain;
 
 	struct DescriptorSizes
 	{
@@ -39,9 +42,11 @@ namespace DXR
 		GraphicsDevice(UINT8 DeviceIndex);
 		ID3D12Device* operator->();
 		IDXGIFactory* GetDXGIFactory();
-		Fence CreateFence(UINT64 initialValue);
 		void CheckSupportedMSAALevels(DXGI_FORMAT backbufferFormat);
 		CommandQueue* GetGraphicsCommandQueue();
+		Fence CreateFence(UINT64 initialValue);
+		GraphicsCommandList CreateGraphicsCommandList();
+		Swapchain CreateSwapchain(Window& window, UINT refreshRate);
 	private:
 		void CreateDXGIFactory();
 		void CreateDefaultD3D12Device();

--- a/DX_Renderer/Core/Components/GraphicsDevice.hpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.hpp
@@ -23,6 +23,7 @@ namespace DXR
 	{
 	// public and private data fields
 	public:
+		std::vector<UINT8> supported_mssa_levels;
 	private:
 		D3D_FEATURE_LEVEL m_minimum_feature_level = D3D_FEATURE_LEVEL_11_0;
 		
@@ -37,12 +38,13 @@ namespace DXR
 		GraphicsDevice(UINT8 DeviceIndex);
 		ID3D12Device* operator->();
 		Fence CreateFence(UINT64 initialValue);
+		void CheckSupportedMSAALevels(DXGI_FORMAT backbufferFormat);
 	private:
 		void CreateDXGIFactory();
 		void CreateDefaultD3D12Device();
 		void CreateD3D12Device(UINT8 deviceIndex);
 		std::vector<WRL::ComPtr<IDXGIAdapter>> GetGraphicsAdapterList() const;
 		void QueryAllDescriptorSizes();
-		UINT64 QueryDescriptoSize(D3D12_DESCRIPTOR_HEAP_TYPE descriptorType);
+		UINT64 QueryDescriptorSize(D3D12_DESCRIPTOR_HEAP_TYPE descriptorType);
 	};
 }

--- a/DX_Renderer/Core/Components/GraphicsDevice.hpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.hpp
@@ -11,16 +11,25 @@ namespace DXR
 	
 	struct Fence;
 
+	struct DescriptorSizes
+	{
+		UINT64 RTV;
+		UINT64 CBV_SRV_UAV;
+		UINT64 DSV;
+		UINT64 Sampler;
+	};
+
 	struct GraphicsDevice
 	{
 	// public and private data fields
 	public:
-		
 	private:
 		D3D_FEATURE_LEVEL m_minimum_feature_level = D3D_FEATURE_LEVEL_11_0;
 		
 		WRL::ComPtr<IDXGIFactory> m_dxgi_factory;
 		WRL::ComPtr <ID3D12Device> m_device;
+
+		DescriptorSizes descriptorSizes;
 
 	// public and privte methods
 	public:
@@ -33,5 +42,7 @@ namespace DXR
 		void CreateDefaultD3D12Device();
 		void CreateD3D12Device(UINT8 deviceIndex);
 		std::vector<WRL::ComPtr<IDXGIAdapter>> GetGraphicsAdapterList() const;
+		void QueryAllDescriptorSizes();
+		UINT64 QueryDescriptoSize(D3D12_DESCRIPTOR_HEAP_TYPE descriptorType);
 	};
 }

--- a/DX_Renderer/Core/Components/GraphicsDevice.hpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <dxgi.h>
+#include <wrl.h>
+#include <vector>
+
+namespace DXR
+{
+	using namespace Microsoft;
+	
+	struct GraphicsDevice
+	{
+	//
+	public:
+		
+	private:
+		WRL::ComPtr<IDXGIFactory> m_dxgi_factory;
+	//
+	public:
+		GraphicsDevice();
+		GraphicsDevice(UINT8 DeviceIndex);
+		std::vector<WRL::ComPtr<IDXGIAdapter>> GetGraphicsAdapterList() const;
+	private:
+		void CreateDXGIFactory();
+		
+	};
+}

--- a/DX_Renderer/Core/Components/GraphicsDevice.hpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.hpp
@@ -49,6 +49,7 @@ namespace DXR
 		GraphicsCommandList CreateGraphicsCommandList();
 		Swapchain CreateSwapchain(Window& window, UINT refreshRate);
 		DescriptorHeap CreateRenderTargetViewDescriptorHeap(const UINT descriptorCount);
+		DescriptorHeap CreateDepthStencilBufferDescriptorHeap(const UINT descriptorCount);
 	private:
 		void CreateDXGIFactory();
 		void CreateDefaultD3D12Device();

--- a/DX_Renderer/Core/Components/GraphicsDevice.hpp
+++ b/DX_Renderer/Core/Components/GraphicsDevice.hpp
@@ -26,7 +26,8 @@ namespace DXR
 		GraphicsDevice(UINT8 DeviceIndex);
 	private:
 		void CreateDXGIFactory();
-		std::vector<WRL::ComPtr<IDXGIAdapter>> GetGraphicsAdapterList() const;
 		void CreateDefaultD3D12Device();
+		void CreateD3D12Device(UINT8 deviceIndex);
+		std::vector<WRL::ComPtr<IDXGIAdapter>> GetGraphicsAdapterList() const;
 	};
 }

--- a/DX_Renderer/Core/Components/Resource/DepthStencilBuffer.cpp
+++ b/DX_Renderer/Core/Components/Resource/DepthStencilBuffer.cpp
@@ -1,0 +1,62 @@
+#include "DepthStencilBuffer.hpp"
+#include "../../../Tooling/Validate.hpp"
+#include "../GraphicsDevice.hpp"
+#include "DescriptorHeap.hpp"
+#include "../Command List/GraphicsCommandList.hpp"
+#include "ResourceBarrier.hpp"
+
+namespace DXR
+{
+	DepthStencilBuffer::DepthStencilBuffer(GraphicsDevice& device, GraphicsCommandList& commandList,
+		DescriptorHeap& heap, Resolution& resolution): Resource(heap)
+	{
+		this->m_resolution = resolution;
+		D3D12_RESOURCE_DESC resource_description = this->DepthStencilBuffer::CreateResourceDescription();
+		D3D12_CLEAR_VALUE optimized_clear_value = this->DepthStencilBuffer::CreateOptimizedClearValue();
+		D3D12_HEAP_PROPERTIES heap_description = this->DepthStencilBuffer::CreateResourceHeapDescription();
+		DXCall(device->CreateCommittedResource(&heap_description,D3D12_HEAP_FLAG_NONE,&resource_description,D3D12_RESOURCE_STATE_COMMON,&optimized_clear_value,IID_PPV_ARGS(&this->m_resource)));
+		device->CreateDepthStencilView(this->m_resource.Get(),nullptr,(*this->m_descriptor_heap)[0]);
+		const ResourceBarrier resource_barrier = {*this->m_resource.Get(),D3D12_RESOURCE_STATE_COMMON,D3D12_RESOURCE_STATE_DEPTH_WRITE};
+		resource_barrier.ExecuteResourceBarrier(commandList);
+	}
+
+	D3D12_RESOURCE_DESC DepthStencilBuffer::CreateResourceDescription()
+	{
+		D3D12_RESOURCE_DESC resource_description = {};
+		resource_description.SampleDesc.Count = 1;
+		resource_description.SampleDesc.Quality = 0;
+		resource_description.Flags = D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL;
+		resource_description.Alignment = 0;
+		resource_description.DepthOrArraySize = 1;
+		resource_description.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+		resource_description.MipLevels = 1;
+		resource_description.Width = this->m_resolution.Width;
+		resource_description.Height = this->m_resolution.Height;
+		resource_description.Format = this->DepthStencilBufferFormat;
+		resource_description.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+		
+		return resource_description;
+	}
+
+	D3D12_CLEAR_VALUE DepthStencilBuffer::CreateOptimizedClearValue()
+	{
+		D3D12_CLEAR_VALUE clear_value = {};
+		clear_value.Format = this->DepthStencilBufferFormat;
+		clear_value.DepthStencil.Depth = 1.0f;
+		clear_value.DepthStencil.Stencil = 0.0f;
+		
+		return clear_value;
+	}
+
+	D3D12_HEAP_PROPERTIES DepthStencilBuffer::CreateResourceHeapDescription()
+	{
+		D3D12_HEAP_PROPERTIES heap_properties = {};
+		heap_properties.Type = D3D12_HEAP_TYPE_DEFAULT;
+		heap_properties.CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN;
+		heap_properties.CreationNodeMask = 1;
+		heap_properties.VisibleNodeMask = 1;
+		heap_properties.MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN;
+		
+		return heap_properties;
+	}
+}

--- a/DX_Renderer/Core/Components/Resource/DepthStencilBuffer.cpp
+++ b/DX_Renderer/Core/Components/Resource/DepthStencilBuffer.cpp
@@ -43,7 +43,7 @@ namespace DXR
 		D3D12_CLEAR_VALUE clear_value = {};
 		clear_value.Format = this->DepthStencilBufferFormat;
 		clear_value.DepthStencil.Depth = 1.0f;
-		clear_value.DepthStencil.Stencil = 0.0f;
+		clear_value.DepthStencil.Stencil = 0;
 		
 		return clear_value;
 	}

--- a/DX_Renderer/Core/Components/Resource/DepthStencilBuffer.cpp
+++ b/DX_Renderer/Core/Components/Resource/DepthStencilBuffer.cpp
@@ -14,10 +14,15 @@ namespace DXR
 		D3D12_RESOURCE_DESC resource_description = this->DepthStencilBuffer::CreateResourceDescription();
 		D3D12_CLEAR_VALUE optimized_clear_value = this->DepthStencilBuffer::CreateOptimizedClearValue();
 		D3D12_HEAP_PROPERTIES heap_description = this->DepthStencilBuffer::CreateResourceHeapDescription();
+
+		INFO_LOG(L"Creating Depth Stencil Buffer GPU Resource And Corresponding CPU Descriptor\n");
 		DXCall(device->CreateCommittedResource(&heap_description,D3D12_HEAP_FLAG_NONE,&resource_description,D3D12_RESOURCE_STATE_COMMON,&optimized_clear_value,IID_PPV_ARGS(&this->m_resource)));
 		device->CreateDepthStencilView(this->m_resource.Get(),nullptr,(*this->m_descriptor_heap)[0]);
+		SUCCESS_LOG(L"Depth Stencil Buffer GPU Resource And CPU Descriptor Created\n");
+
 		const ResourceBarrier resource_barrier = {*this->m_resource.Get(),D3D12_RESOURCE_STATE_COMMON,D3D12_RESOURCE_STATE_DEPTH_WRITE};
 		resource_barrier.ExecuteResourceBarrier(commandList);
+		INFO_LOG(L"Queued Resource Barrier Into Command List For Execution\n");
 	}
 
 	D3D12_RESOURCE_DESC DepthStencilBuffer::CreateResourceDescription()

--- a/DX_Renderer/Core/Components/Resource/DepthStencilBuffer.hpp
+++ b/DX_Renderer/Core/Components/Resource/DepthStencilBuffer.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "Resource.hpp"
+#include "../../Windows Abstractions/Window.hpp"
+
+namespace DXR
+{
+
+	struct GraphicsDevice;
+	struct GraphicsCommandList;
+	struct DescriptorHeap;
+	
+	class DepthStencilBuffer : public Resource
+	{
+	public:
+		const DXGI_FORMAT DepthStencilBufferFormat = DXGI_FORMAT::DXGI_FORMAT_D32_FLOAT_S8X24_UINT;
+	private:
+		Resolution m_resolution;
+	public:
+		DepthStencilBuffer(GraphicsDevice& device, GraphicsCommandList& commandList,DescriptorHeap& heap,Resolution& resolution);
+	protected:
+		D3D12_RESOURCE_DESC CreateResourceDescription() override;
+		D3D12_CLEAR_VALUE CreateOptimizedClearValue() override;
+		D3D12_HEAP_PROPERTIES CreateResourceHeapDescription() override;
+	};
+}

--- a/DX_Renderer/Core/Components/Resource/DepthStencilBuffer.hpp
+++ b/DX_Renderer/Core/Components/Resource/DepthStencilBuffer.hpp
@@ -10,7 +10,7 @@ namespace DXR
 	struct GraphicsCommandList;
 	struct DescriptorHeap;
 	
-	class DepthStencilBuffer : public Resource
+	struct DepthStencilBuffer : public Resource
 	{
 	public:
 		const DXGI_FORMAT DepthStencilBufferFormat = DXGI_FORMAT::DXGI_FORMAT_D32_FLOAT_S8X24_UINT;

--- a/DX_Renderer/Core/Components/Resource/DescriptorHeap.cpp
+++ b/DX_Renderer/Core/Components/Resource/DescriptorHeap.cpp
@@ -4,6 +4,15 @@
 
 namespace DXR
 {
+	void DescriptorHeap::operator=(const DescriptorHeap& other)
+	{
+		this->ContainedDescriptorType = other.ContainedDescriptorType;
+		this->DescriptorCount = other.DescriptorCount;
+		this->m_descriptor_handle_increment_size = other.m_descriptor_handle_increment_size;
+		this->m_descriptor_heap.Reset();
+		this->m_descriptor_heap = other.m_descriptor_heap;
+	}
+
 	D3D12_CPU_DESCRIPTOR_HANDLE DescriptorHeap::operator[](const size_t index) const
 	{
 		if(index < this->DescriptorCount)

--- a/DX_Renderer/Core/Components/Resource/DescriptorHeap.cpp
+++ b/DX_Renderer/Core/Components/Resource/DescriptorHeap.cpp
@@ -10,7 +10,7 @@ namespace DXR
 		this->DescriptorCount = other.DescriptorCount;
 		this->m_descriptor_handle_increment_size = other.m_descriptor_handle_increment_size;
 		this->m_descriptor_heap.Reset();
-		this->m_descriptor_heap = other.m_descriptor_heap;
+		other.m_descriptor_heap.CopyTo(&this->m_descriptor_heap);
 	}
 
 	D3D12_CPU_DESCRIPTOR_HANDLE DescriptorHeap::operator[](const size_t index) const

--- a/DX_Renderer/Core/Components/Resource/DescriptorHeap.cpp
+++ b/DX_Renderer/Core/Components/Resource/DescriptorHeap.cpp
@@ -1,6 +1,62 @@
 #include "DescriptorHeap.hpp"
+#include "../GraphicsDevice.hpp"
+#include "../../../Tooling/Validate.hpp"
 
 namespace DXR
 {
-	
+	D3D12_CPU_DESCRIPTOR_HANDLE DescriptorHeap::operator[](const size_t index) const
+	{
+		if(index < this->DescriptorCount)
+		{
+			return {this->m_descriptor_heap->GetCPUDescriptorHandleForHeapStart().ptr + index * this->m_descriptor_handle_increment_size};
+		}
+		return {NULL};
+	}
+
+	DescriptorHeap::DescriptorHeap(GraphicsDevice& device, UINT8 descriptorCount, DescriptorType type)
+		:ContainedDescriptorType(type), DescriptorCount(descriptorCount)
+	{
+		const DescriptorSizes descriptor_sizes = device.GetDescriptorSizes();
+		switch(type)
+		{
+			case DescriptorType::RenderTargetView:
+			{
+				this->m_descriptor_handle_increment_size = descriptor_sizes.RTV;
+				this->m_heap_type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+				break;
+			}
+			case DescriptorType::DepthStencilBuffer:
+			{
+				this->m_descriptor_handle_increment_size = descriptor_sizes.DSV;
+				this->m_heap_type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+				break;
+			}
+			case DescriptorType::ConstantBufferView:
+			{
+				this->m_descriptor_handle_increment_size = descriptor_sizes.CBV_SRV_UAV;
+				this->m_heap_type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+				break;
+			}
+			case DescriptorType::Sampler:
+			{
+				this->m_descriptor_handle_increment_size = descriptor_sizes.Sampler;
+				this->m_heap_type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
+				break;
+			}
+			default:
+				break;
+		}
+		this->CreateDescriptorHeap(device);
+	}
+
+	void DescriptorHeap::CreateDescriptorHeap(GraphicsDevice& device)
+	{
+		D3D12_DESCRIPTOR_HEAP_DESC heap_description = {};
+		heap_description.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		heap_description.NodeMask = 0;
+		heap_description.NumDescriptors = this->DescriptorCount;
+		heap_description.Type = this->m_heap_type;
+
+		DXCall(device->CreateDescriptorHeap(&heap_description, IID_PPV_ARGS(&this->m_descriptor_heap)));
+	}
 }

--- a/DX_Renderer/Core/Components/Resource/DescriptorHeap.cpp
+++ b/DX_Renderer/Core/Components/Resource/DescriptorHeap.cpp
@@ -1,0 +1,6 @@
+#include "DescriptorHeap.hpp"
+
+namespace DXR
+{
+	
+}

--- a/DX_Renderer/Core/Components/Resource/DescriptorHeap.cpp
+++ b/DX_Renderer/Core/Components/Resource/DescriptorHeap.cpp
@@ -6,19 +6,23 @@ namespace DXR
 {
 	void DescriptorHeap::operator=(const DescriptorHeap& other)
 	{
+		INFO_LOG(L"Copying Descriptor Heap\n");
 		this->ContainedDescriptorType = other.ContainedDescriptorType;
 		this->DescriptorCount = other.DescriptorCount;
 		this->m_descriptor_handle_increment_size = other.m_descriptor_handle_increment_size;
 		this->m_descriptor_heap.Reset();
-		other.m_descriptor_heap.CopyTo(&this->m_descriptor_heap);
+		DXCall(other.m_descriptor_heap.CopyTo(&this->m_descriptor_heap));
+		SUCCESS_LOG(L"Finished Copying Descriptor Heap\n");
 	}
 
 	D3D12_CPU_DESCRIPTOR_HANDLE DescriptorHeap::operator[](const size_t index) const
 	{
 		if(index < this->DescriptorCount)
 		{
+			INFO_LOG(L"Fetched Descriptor Handle From Descriptor Heap\n");
 			return {this->m_descriptor_heap->GetCPUDescriptorHandleForHeapStart().ptr + index * this->m_descriptor_handle_increment_size};
 		}
+		WARNING_LOG(L"Attempt To Access Out Of Bound Descriptor Handle From Descriptor Heap\n");
 		return {NULL};
 	}
 
@@ -30,24 +34,28 @@ namespace DXR
 		{
 			case DescriptorType::RenderTargetView:
 			{
+				INFO_LOG(L"Creating Render Target View Descript Heap\n");
 				this->m_descriptor_handle_increment_size = descriptor_sizes.RTV;
 				this->m_heap_type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
 				break;
 			}
 			case DescriptorType::DepthStencilBuffer:
 			{
+				INFO_LOG(L"Creating Depth Stencil View Descriptor Heap\n");
 				this->m_descriptor_handle_increment_size = descriptor_sizes.DSV;
 				this->m_heap_type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
 				break;
 			}
 			case DescriptorType::ConstantBufferView:
 			{
+				INFO_LOG(L"Creating Constant Buffer View, Shader Resource View and Unordered Access View Descriptor Heap\n");
 				this->m_descriptor_handle_increment_size = descriptor_sizes.CBV_SRV_UAV;
 				this->m_heap_type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
 				break;
 			}
 			case DescriptorType::Sampler:
 			{
+				INFO_LOG(L"Creating Sampler Descripor Heap\n");
 				this->m_descriptor_handle_increment_size = descriptor_sizes.Sampler;
 				this->m_heap_type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
 				break;
@@ -66,6 +74,8 @@ namespace DXR
 		heap_description.NumDescriptors = this->DescriptorCount;
 		heap_description.Type = this->m_heap_type;
 
+		INFO_LOG(L"Creating Descriptor Heap\n");
 		DXCall(device->CreateDescriptorHeap(&heap_description, IID_PPV_ARGS(&this->m_descriptor_heap)));
+		SUCCESS_LOG(L"Descriptor Heap Created\n");
 	}
 }

--- a/DX_Renderer/Core/Components/Resource/DescriptorHeap.hpp
+++ b/DX_Renderer/Core/Components/Resource/DescriptorHeap.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <wrl.h>
+#include <d3d12.h>
+
+namespace DXR
+{
+
+	using namespace Microsoft;
+
+	struct GraphicsDevice;
+
+	enum class DescriptorType
+	{
+		RenderTargetView,
+		DepthStencilBuffer,
+		ConstantBufferView,
+		Sampler
+	};
+	
+	struct DescriptorHeap
+	{
+	public:
+		const DescriptorType DescriptorType;
+	private:
+		WRL::ComPtr<ID3D12DescriptorHeap> m_descriptor_heap;
+	private:
+		void CreateDescriptorHeap(GraphicsDevice& device);
+	};
+
+}

--- a/DX_Renderer/Core/Components/Resource/DescriptorHeap.hpp
+++ b/DX_Renderer/Core/Components/Resource/DescriptorHeap.hpp
@@ -15,20 +15,23 @@ namespace DXR
 		RenderTargetView,
 		DepthStencilBuffer,
 		ConstantBufferView,
-		Sampler
+		Sampler,
+		None
 	};
 	
 	struct DescriptorHeap
 	{
 	public:
 		friend GraphicsDevice;
-		const DescriptorType ContainedDescriptorType;
-		const UINT DescriptorCount;
 	private:
-		UINT64 m_descriptor_handle_increment_size;
+		DescriptorType ContainedDescriptorType = DescriptorType::None;
+		UINT DescriptorCount = 0;
+		UINT64 m_descriptor_handle_increment_size = 0;
 		D3D12_DESCRIPTOR_HEAP_TYPE m_heap_type;
 		WRL::ComPtr<ID3D12DescriptorHeap> m_descriptor_heap;
 	public:
+		DescriptorHeap(){}
+		void operator=(const DescriptorHeap& other);
 		D3D12_CPU_DESCRIPTOR_HANDLE operator[](const size_t index) const;
 	private:
 		DescriptorHeap(GraphicsDevice& device, UINT8 descriptorCount, DescriptorType type);

--- a/DX_Renderer/Core/Components/Resource/DescriptorHeap.hpp
+++ b/DX_Renderer/Core/Components/Resource/DescriptorHeap.hpp
@@ -21,11 +21,18 @@ namespace DXR
 	struct DescriptorHeap
 	{
 	public:
-		const DescriptorType DescriptorType;
+		friend GraphicsDevice;
+		const DescriptorType ContainedDescriptorType;
+		const UINT8 DescriptorCount;
 	private:
+		UINT m_descriptor_handle_increment_size;
+		D3D12_DESCRIPTOR_HEAP_TYPE m_heap_type;
 		WRL::ComPtr<ID3D12DescriptorHeap> m_descriptor_heap;
+	public:
+		D3D12_CPU_DESCRIPTOR_HANDLE operator[](const size_t index) const;
 	private:
-		void CreateDescriptorHeap(GraphicsDevice& device);
+		DescriptorHeap(GraphicsDevice& device, UINT8 descriptorCount, DescriptorType type);
+		inline void CreateDescriptorHeap(GraphicsDevice& device);
 	};
 
 }

--- a/DX_Renderer/Core/Components/Resource/DescriptorHeap.hpp
+++ b/DX_Renderer/Core/Components/Resource/DescriptorHeap.hpp
@@ -23,9 +23,9 @@ namespace DXR
 	public:
 		friend GraphicsDevice;
 		const DescriptorType ContainedDescriptorType;
-		const UINT8 DescriptorCount;
+		const UINT DescriptorCount;
 	private:
-		UINT m_descriptor_handle_increment_size;
+		UINT64 m_descriptor_handle_increment_size;
 		D3D12_DESCRIPTOR_HEAP_TYPE m_heap_type;
 		WRL::ComPtr<ID3D12DescriptorHeap> m_descriptor_heap;
 	public:

--- a/DX_Renderer/Core/Components/Resource/Resource.cpp
+++ b/DX_Renderer/Core/Components/Resource/Resource.cpp
@@ -1,0 +1,13 @@
+#include "Resource.hpp"
+
+namespace DXR
+{
+	ID3D12Resource* Resource::operator->() const
+	{
+		return this->m_resource.Get();
+	}
+
+	Resource::Resource(DescriptorHeap& heap) :m_descriptor_heap(&heap)
+	{
+	}
+}

--- a/DX_Renderer/Core/Components/Resource/Resource.cpp
+++ b/DX_Renderer/Core/Components/Resource/Resource.cpp
@@ -7,7 +7,6 @@ namespace DXR
 		return this->m_resource.Get();
 	}
 
-	Resource::Resource(DescriptorHeap& heap) :m_descriptor_heap(&heap)
-	{
-	}
+	Resource::Resource(DescriptorHeap& heap) :m_descriptor_heap(&heap){}
+	
 }

--- a/DX_Renderer/Core/Components/Resource/Resource.hpp
+++ b/DX_Renderer/Core/Components/Resource/Resource.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <d3d12.h>
+#include <wrl.h>
+
+namespace DXR
+{
+	using namespace Microsoft;
+
+	struct DescriptorHeap;
+
+	struct Resource
+	{
+	public:
+	protected:
+		WRL::ComPtr<ID3D12Resource> m_resource;
+		DescriptorHeap* m_descriptor_heap = nullptr;// Non owning pointer to resource descriptor heap
+		D3D12_RESOURCE_DESC m_resource_description = {};
+		D3D12_CLEAR_VALUE m_optimized_clear_value = {};
+		D3D12_HEAP_PROPERTIES m_resource_heap_description = {};
+	public:
+		ID3D12Resource* operator->() const;
+	protected:
+		Resource(DescriptorHeap& heap);
+		virtual D3D12_RESOURCE_DESC CreateResourceDescription() = 0;
+		virtual D3D12_CLEAR_VALUE CreateOptimizedClearValue() = 0;
+		virtual D3D12_HEAP_PROPERTIES CreateResourceHeapDescription() = 0;
+	};
+
+};

--- a/DX_Renderer/Core/Components/Resource/Resource.hpp
+++ b/DX_Renderer/Core/Components/Resource/Resource.hpp
@@ -20,6 +20,7 @@ namespace DXR
 		D3D12_HEAP_PROPERTIES m_resource_heap_description = {};
 	public:
 		ID3D12Resource* operator->() const;
+		virtual ~Resource() = default;
 	protected:
 		Resource(DescriptorHeap& heap);
 		virtual D3D12_RESOURCE_DESC CreateResourceDescription() = 0;

--- a/DX_Renderer/Core/Components/Resource/ResourceBarrier.cpp
+++ b/DX_Renderer/Core/Components/Resource/ResourceBarrier.cpp
@@ -1,6 +1,7 @@
 #include "ResourceBarrier.hpp"
 
 #include "../Command List/GraphicsCommandList.hpp"
+#include "../../../Tooling/Log.hpp"
 
 namespace DXR
 {
@@ -24,5 +25,6 @@ namespace DXR
 	void ResourceBarrier::ExecuteResourceBarrier(GraphicsCommandList& commandList) const
 	{
 		commandList->ResourceBarrier(1,&this->m_resource_barrier);
+		INFO_LOG(L"Queued Resource Barrier Into Command Queue\n");
 	}
 }

--- a/DX_Renderer/Core/Components/Resource/ResourceBarrier.cpp
+++ b/DX_Renderer/Core/Components/Resource/ResourceBarrier.cpp
@@ -1,0 +1,28 @@
+#include "ResourceBarrier.hpp"
+
+#include "../Command List/GraphicsCommandList.hpp"
+
+namespace DXR
+{
+	ResourceBarrier::ResourceBarrier(ID3D12Resource& resource, D3D12_RESOURCE_STATES initialState,
+		D3D12_RESOURCE_STATES afterState):m_initial_state(initialState),m_after_state(afterState),m_resource(&resource)
+	{
+		this->CreateResourceBarrier();
+	}
+
+	void ResourceBarrier::CreateResourceBarrier()
+	{
+		this->m_resource_barrier = {};
+		this->m_resource_barrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+		this->m_resource_barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+		this->m_resource_barrier.Transition.StateBefore = this->m_initial_state;
+		this->m_resource_barrier.Transition.StateAfter = this->m_after_state;
+		this->m_resource_barrier.Transition.pResource = m_resource;
+		this->m_resource_barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+	}
+
+	void ResourceBarrier::ExecuteResourceBarrier(GraphicsCommandList& commandList) const
+	{
+		commandList->ResourceBarrier(1,&this->m_resource_barrier);
+	}
+}

--- a/DX_Renderer/Core/Components/Resource/ResourceBarrier.hpp
+++ b/DX_Renderer/Core/Components/Resource/ResourceBarrier.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <d3d12.h>
+
+namespace DXR
+{
+
+	struct GraphicsCommandList;
+	
+	class ResourceBarrier
+	{
+	public:
+	private:
+		D3D12_RESOURCE_STATES m_initial_state;
+		D3D12_RESOURCE_STATES m_after_state;
+		ID3D12Resource* m_resource;
+		D3D12_RESOURCE_BARRIER m_resource_barrier = {};
+	public:
+		ResourceBarrier(ID3D12Resource& resource,D3D12_RESOURCE_STATES initialState, D3D12_RESOURCE_STATES afterState);
+		void ExecuteResourceBarrier(GraphicsCommandList& commandList) const;
+	private:
+		inline void CreateResourceBarrier();
+	};
+	
+}

--- a/DX_Renderer/Core/Components/Swapchain.cpp
+++ b/DX_Renderer/Core/Components/Swapchain.cpp
@@ -36,6 +36,7 @@ namespace DXR
 	inline void Swapchain::CreateSwapChain(GraphicsDevice& device, Window& window)
 	{
 		this->m_swapchain.Reset();
+		INFO_LOG(L"Swapchain ComPtr references reset\n");
 
 		// description of the swapchain buffers
 		DXGI_MODE_DESC swapchain_buffer_description = {};
@@ -59,16 +60,20 @@ namespace DXR
 		swapchain_description.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
 		swapchain_description.OutputWindow = window.GetWindowHandle();
 
+		INFO_LOG(L"Creating Swapchain\n");
 		DXCall(device.GetDXGIFactory()->CreateSwapChain(device.GetGraphicsCommandQueue()->GetCommandQueueRawPtr(), &swapchain_description, this->m_swapchain.GetAddressOf()));
+		SUCCESS_LOG(L"Swapchain Created\n");
 	}
 
 	void Swapchain::CreateRenderTargetViews(GraphicsDevice& device) const
 	{
 		for(UINT i = 0;i < this->m_swapchain_buffer_count;++i)
 		{
+			INFO_LOG(L"Creating Backbuffer Render Target View\n");
 			WRL::ComPtr<ID3D12Resource> backbuffer;
 			DXCall(this->m_swapchain->GetBuffer(i, IID_PPV_ARGS(&backbuffer)));
 			device->CreateRenderTargetView(backbuffer.Get(), nullptr, this->m_RTV_descriptor_heap[i]);
+			SUCCESS_LOG(L"Backbuffer Render Target View Created\n");
 		}
 	}
 
@@ -88,6 +93,7 @@ namespace DXR
 		viewport.TopLeftY = yOffset;
 
 		commandList->RSSetViewports(1, &viewport);
+		INFO_LOG(L"Set Viewport In Command List\n");
 	}
 
 	void Swapchain::Present(GraphicsCommandList& commandList)

--- a/DX_Renderer/Core/Components/Swapchain.cpp
+++ b/DX_Renderer/Core/Components/Swapchain.cpp
@@ -92,8 +92,9 @@ namespace DXR
 
 	void Swapchain::Present(GraphicsCommandList& commandList)
 	{
-		INFO_LOG(L"Swapchain Update\n");
-		this->m_swapchain->Present(0, 0);
+		//INFO_LOG(L"Attempting To Present\n");
+		DXCall(this->m_swapchain->Present(0, 0));
+		//INFO_LOG(L"Done Presenting\n");
 		this->m_current_backbuffer = this->m_backbuffer_format == 1 ? 0 : 1;
 	}
 }

--- a/DX_Renderer/Core/Components/Swapchain.cpp
+++ b/DX_Renderer/Core/Components/Swapchain.cpp
@@ -33,14 +33,8 @@ namespace DXR
 
 		// description of the swapchain
 		DXGI_SWAP_CHAIN_DESC swapchain_description = {};
-		if(this->m_use_msaa)
-		{
-			swapchain_description.SampleDesc.Count = 1;//device.supported_mssa_levels[device.supported_mssa_levels.size() - 1];
-			swapchain_description.SampleDesc.Quality = 0;
-		} else {
-			swapchain_description.SampleDesc.Count = 1;
-			swapchain_description.SampleDesc.Quality = 0;
-		}
+		swapchain_description.SampleDesc.Count = 1;
+		swapchain_description.SampleDesc.Quality = 0;
 		swapchain_description.BufferDesc = swapchain_buffer_description;
 		swapchain_description.BufferCount = this->m_swapchain_buffer_count;
 		swapchain_description.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;

--- a/DX_Renderer/Core/Components/Swapchain.cpp
+++ b/DX_Renderer/Core/Components/Swapchain.cpp
@@ -14,7 +14,6 @@ namespace DXR
 	{
 		device.CheckSupportedMSAALevels(this->m_backbuffer_format);
 		this->m_RTV_descriptor_heap = device.CreateRenderTargetViewDescriptorHeap(this->m_swapchain_buffer_count);
-		this->m_DSV_descriptor_heap = device.CreateDepthStencilBufferDescriptorHeap(1);
 		this->CreateSwapChain(device, window);
 		this->CreateRenderTargetViews(device);
 	}
@@ -24,7 +23,6 @@ namespace DXR
 	{
 		device.CheckSupportedMSAALevels(this->m_backbuffer_format);
 		this->m_RTV_descriptor_heap = device.CreateRenderTargetViewDescriptorHeap(this->m_swapchain_buffer_count);
-		this->m_DSV_descriptor_heap = device.CreateDepthStencilBufferDescriptorHeap(1);
 		this->CreateSwapChain(device, window);
 		this->CreateRenderTargetViews(device);
 	}
@@ -58,7 +56,7 @@ namespace DXR
 		DXCall(device.GetDXGIFactory()->CreateSwapChain(device.GetGraphicsCommandQueue()->GetCommandQueueRawPtr(), &swapchain_description, this->m_swapchain.GetAddressOf()));
 	}
 
-	void Swapchain::CreateRenderTargetViews(GraphicsDevice& device)
+	void Swapchain::CreateRenderTargetViews(GraphicsDevice& device) const
 	{
 		for(size_t i=0;i<this->m_swapchain_buffer_count;++i)
 		{

--- a/DX_Renderer/Core/Components/Swapchain.cpp
+++ b/DX_Renderer/Core/Components/Swapchain.cpp
@@ -92,9 +92,7 @@ namespace DXR
 
 	void Swapchain::Present(GraphicsCommandList& commandList)
 	{
-		//INFO_LOG(L"Attempting To Present\n");
 		DXCall(this->m_swapchain->Present(0, 0));
-		//INFO_LOG(L"Done Presenting\n");
 		this->m_current_backbuffer = this->m_backbuffer_format == 1 ? 0 : 1;
 	}
 }

--- a/DX_Renderer/Core/Components/Swapchain.cpp
+++ b/DX_Renderer/Core/Components/Swapchain.cpp
@@ -76,4 +76,24 @@ namespace DXR
 	{
 		this->m_depth_stencil_buffer_resource = std::make_unique<DepthStencilBuffer>(device, commandList, this->m_DSV_descriptor_heap, this->m_resolution);
 	}
+
+	void Swapchain::SetViewport(GraphicsCommandList& commandList, Resolution& resolution, UINT xOffset, UINT yOffset)
+	{
+		D3D12_VIEWPORT viewport = {};
+		viewport.Width = resolution.Width;
+		viewport.Height = resolution.Height;
+		viewport.MinDepth = 0;
+		viewport.MaxDepth = 1;
+		viewport.TopLeftX = xOffset;
+		viewport.TopLeftY = yOffset;
+
+		commandList->RSSetViewports(1, &viewport);
+	}
+
+	void Swapchain::Present(GraphicsCommandList& commandList)
+	{
+		INFO_LOG(L"Swapchain Update\n");
+		this->m_swapchain->Present(0, 0);
+		this->m_current_backbuffer = this->m_backbuffer_format == 1 ? 0 : 1;
+	}
 }

--- a/DX_Renderer/Core/Components/Swapchain.cpp
+++ b/DX_Renderer/Core/Components/Swapchain.cpp
@@ -1,5 +1,6 @@
 #include "Swapchain.hpp"
 #include "../../Tooling/Validate.hpp"
+#include "GraphicsDevice.hpp"
 
 namespace DXR
 {
@@ -12,14 +13,20 @@ namespace DXR
 		:m_resolution(window.GetResolution()), m_refresh_rate(refreshRate)
 	{
 		device.CheckSupportedMSAALevels(this->m_backbuffer_format);
+		this->m_RTV_descriptor_heap = device.CreateRenderTargetViewDescriptorHeap(this->m_swapchain_buffer_count);
+		this->m_DSV_descriptor_heap = device.CreateDepthStencilBufferDescriptorHeap(1);
 		this->CreateSwapChain(device, window);
+		this->CreateRenderTargetViews(device);
 	}
 
 	Swapchain::Swapchain(GraphicsDevice& device, Window& window, UINT16 refreshRate, DXGI_FORMAT backbufferFormat)
 		: m_resolution(window.GetResolution()), m_refresh_rate(refreshRate), m_backbuffer_format(backbufferFormat)
 	{
 		device.CheckSupportedMSAALevels(this->m_backbuffer_format);
+		this->m_RTV_descriptor_heap = device.CreateRenderTargetViewDescriptorHeap(this->m_swapchain_buffer_count);
+		this->m_DSV_descriptor_heap = device.CreateDepthStencilBufferDescriptorHeap(1);
 		this->CreateSwapChain(device, window);
+		this->CreateRenderTargetViews(device);
 	}
 
 	inline void Swapchain::CreateSwapChain(GraphicsDevice& device, Window& window)
@@ -49,5 +56,14 @@ namespace DXR
 		swapchain_description.OutputWindow = window.GetWindowHandle();
 
 		DXCall(device.GetDXGIFactory()->CreateSwapChain(device.GetGraphicsCommandQueue()->GetCommandQueueRawPtr(), &swapchain_description, this->m_swapchain.GetAddressOf()));
+	}
+
+	void Swapchain::CreateRenderTargetViews(GraphicsDevice& device)
+	{
+		for(size_t i=0;i<this->m_swapchain_buffer_count;++i)
+		{
+			WRL::ComPtr<ID3D12Resource> backbuffer;
+			DXCall(this->m_swapchain->GetBuffer(i,IID_PPV_ARGS(&backbuffer)));
+		}
 	}
 }

--- a/DX_Renderer/Core/Components/Swapchain.cpp
+++ b/DX_Renderer/Core/Components/Swapchain.cpp
@@ -64,6 +64,7 @@ namespace DXR
 		{
 			WRL::ComPtr<ID3D12Resource> backbuffer;
 			DXCall(this->m_swapchain->GetBuffer(i,IID_PPV_ARGS(&backbuffer)));
+			device->CreateRenderTargetView(backbuffer.Get(),nullptr,this->m_RTV_descriptor_heap[i]);
 		}
 	}
 }

--- a/DX_Renderer/Core/Components/Swapchain.cpp
+++ b/DX_Renderer/Core/Components/Swapchain.cpp
@@ -1,15 +1,20 @@
 #include "Swapchain.hpp"
+#include "../../Tooling/Validate.hpp"
 
 namespace DXR
 {
 	Swapchain::Swapchain(GraphicsDevice& device, Window& window, UINT16 refreshRate)
 		:m_resolution(window.GetResolution()), m_refresh_rate(refreshRate)
 	{
+		device.CheckSupportedMSAALevels(this->m_backbuffer_format);
+		this->CreateSwapChain(device, window);
 	}
 
 	Swapchain::Swapchain(GraphicsDevice& device, Window& window, UINT16 refreshRate, DXGI_FORMAT backbufferFormat)
 		: m_resolution(window.GetResolution()), m_refresh_rate(refreshRate), m_backbuffer_format(backbufferFormat)
 	{
+		device.CheckSupportedMSAALevels(this->m_backbuffer_format);
+		this->CreateSwapChain(device, window);
 	}
 
 	inline void Swapchain::CreateSwapChain(GraphicsDevice& device, Window& window)
@@ -28,6 +33,22 @@ namespace DXR
 
 		// description of the swapchain
 		DXGI_SWAP_CHAIN_DESC swapchain_description = {};
+		if(this->m_use_msaa)
+		{
+			swapchain_description.SampleDesc.Count = device.supported_mssa_levels[device.supported_mssa_levels.size() - 1];
+			swapchain_description.SampleDesc.Quality = 0;
+		} else {
+			swapchain_description.SampleDesc.Count = 1;
+			swapchain_description.SampleDesc.Quality = 0;
+		}
+		swapchain_description.BufferDesc = swapchain_buffer_description;
+		swapchain_description.BufferCount = this->m_swapchain_buffer_count;
+		swapchain_description.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+		swapchain_description.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
+		swapchain_description.Windowed = this->m_windowed_mode;// ? 1 : 0;// convert from C++ bool to a WinAPI BOOL
+		swapchain_description.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+		swapchain_description.OutputWindow = window.GetWindowHandle();
 
+		DXCall(device.GetDXGIFactory()->CreateSwapChain(device.GetGraphicsCommandQueue()->GetCommandQueueRawPtr(), &swapchain_description, this->m_swapchain.GetAddressOf()));
 	}
 }

--- a/DX_Renderer/Core/Components/Swapchain.cpp
+++ b/DX_Renderer/Core/Components/Swapchain.cpp
@@ -1,0 +1,33 @@
+#include "Swapchain.hpp"
+
+namespace DXR
+{
+	Swapchain::Swapchain(GraphicsDevice& device, Window& window, UINT16 refreshRate)
+		:m_resolution(window.GetResolution()), m_refresh_rate(refreshRate)
+	{
+	}
+
+	Swapchain::Swapchain(GraphicsDevice& device, Window& window, UINT16 refreshRate, DXGI_FORMAT backbufferFormat)
+		: m_resolution(window.GetResolution()), m_refresh_rate(refreshRate), m_backbuffer_format(backbufferFormat)
+	{
+	}
+
+	inline void Swapchain::CreateSwapChain(GraphicsDevice& device, Window& window)
+	{
+		this->m_swapchain.Reset();
+
+		// description of the swapchain buffers
+		DXGI_MODE_DESC swapchain_buffer_description = {};
+		swapchain_buffer_description.Width = this->m_resolution.Width;
+		swapchain_buffer_description.Height = this->m_resolution.Height;
+		swapchain_buffer_description.Format = this->m_backbuffer_format;
+		swapchain_buffer_description.RefreshRate.Numerator = this->m_refresh_rate;
+		swapchain_buffer_description.RefreshRate.Denominator = 1;
+		swapchain_buffer_description.Scaling = DXGI_MODE_SCALING_UNSPECIFIED;
+		swapchain_buffer_description.ScanlineOrdering = DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED;
+
+		// description of the swapchain
+		DXGI_SWAP_CHAIN_DESC swapchain_description = {};
+
+	}
+}

--- a/DX_Renderer/Core/Components/Swapchain.cpp
+++ b/DX_Renderer/Core/Components/Swapchain.cpp
@@ -3,6 +3,11 @@
 
 namespace DXR
 {
+	IDXGISwapChain* Swapchain::operator->()
+	{
+		return this->m_swapchain.Get();
+	}
+
 	Swapchain::Swapchain(GraphicsDevice& device, Window& window, UINT16 refreshRate)
 		:m_resolution(window.GetResolution()), m_refresh_rate(refreshRate)
 	{

--- a/DX_Renderer/Core/Components/Swapchain.cpp
+++ b/DX_Renderer/Core/Components/Swapchain.cpp
@@ -35,7 +35,7 @@ namespace DXR
 		DXGI_SWAP_CHAIN_DESC swapchain_description = {};
 		if(this->m_use_msaa)
 		{
-			swapchain_description.SampleDesc.Count = device.supported_mssa_levels[device.supported_mssa_levels.size() - 1];
+			swapchain_description.SampleDesc.Count = 1;//device.supported_mssa_levels[device.supported_mssa_levels.size() - 1];
 			swapchain_description.SampleDesc.Quality = 0;
 		} else {
 			swapchain_description.SampleDesc.Count = 1;
@@ -45,7 +45,7 @@ namespace DXR
 		swapchain_description.BufferCount = this->m_swapchain_buffer_count;
 		swapchain_description.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
 		swapchain_description.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
-		swapchain_description.Windowed = this->m_windowed_mode;// ? 1 : 0;// convert from C++ bool to a WinAPI BOOL
+		swapchain_description.Windowed = this->m_windowed_mode ? 1 : 0;// convert from C++ bool to a WinAPI BOOL
 		swapchain_description.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
 		swapchain_description.OutputWindow = window.GetWindowHandle();
 

--- a/DX_Renderer/Core/Components/Swapchain.hpp
+++ b/DX_Renderer/Core/Components/Swapchain.hpp
@@ -23,13 +23,13 @@ namespace DXR
 		WRL::ComPtr<IDXGISwapChain> m_swapchain;
 		DXGI_FORMAT m_backbuffer_format = DXGI_FORMAT::DXGI_FORMAT_R8G8B8A8_UNORM;
 		DescriptorHeap m_RTV_descriptor_heap;
-		DescriptorHeap m_DSV_descriptor_heap;
 	public:
 		IDXGISwapChain* operator->();
 	private:
 		Swapchain(GraphicsDevice& device, Window& window, UINT16 refreshRate);
 		Swapchain(GraphicsDevice& device, Window& window, UINT16 refreshRate, DXGI_FORMAT backbufferFormat);
 		inline void CreateSwapChain(GraphicsDevice& device, Window& window);
-		inline void CreateRenderTargetViews(GraphicsDevice& device);
+		inline void CreateRenderTargetViews(GraphicsDevice& device) const;
+		inline void CreateDepthStencilBufferView(GraphicsDevice& device);
 	};
 }

--- a/DX_Renderer/Core/Components/Swapchain.hpp
+++ b/DX_Renderer/Core/Components/Swapchain.hpp
@@ -12,17 +12,19 @@ namespace DXR
 	struct Swapchain
 	{
 	public:
+		friend GraphicsDevice;
 	private:
 		bool m_windowed_mode = true;
 		const UINT8 m_swapchain_buffer_count = 2;
 		Resolution m_resolution;
 		UINT16 m_refresh_rate;
 		WRL::ComPtr<IDXGISwapChain> m_swapchain;
-		DXGI_FORMAT m_backbuffer_format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		DXGI_FORMAT m_backbuffer_format = DXGI_FORMAT::DXGI_FORMAT_R8G8B8A8_UNORM;
 	public:
+		IDXGISwapChain* operator->();
+	private:
 		Swapchain(GraphicsDevice& device, Window& window, UINT16 refreshRate);
 		Swapchain(GraphicsDevice& device, Window& window, UINT16 refreshRate, DXGI_FORMAT backbufferFormat);
-	private:
 		inline void CreateSwapChain(GraphicsDevice& device, Window& window);
 	};
 }

--- a/DX_Renderer/Core/Components/Swapchain.hpp
+++ b/DX_Renderer/Core/Components/Swapchain.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <wrl.h>
+#include <dxgi.h>
+#include "../Windows Abstractions/Window.hpp"
+#include "GraphicsDevice.hpp"
+
+namespace DXR
+{
+	using namespace Microsoft;
+
+	struct Swapchain
+	{
+	public:
+	private:
+		bool m_use_msaa = true;
+		const UINT8 m_swapchain_buffer_count = 2;
+		Resolution m_resolution;
+		UINT16 m_refresh_rate;
+		WRL::ComPtr<IDXGISwapChain> m_swapchain;
+		DXGI_FORMAT m_backbuffer_format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	public:
+		Swapchain(GraphicsDevice& device, Window& window, UINT16 refreshRate);
+		Swapchain(GraphicsDevice& device, Window& window, UINT16 refreshRate, DXGI_FORMAT backbufferFormat);
+	private:
+		inline void CreateSwapChain(GraphicsDevice& device, Window& window);
+	};
+}

--- a/DX_Renderer/Core/Components/Swapchain.hpp
+++ b/DX_Renderer/Core/Components/Swapchain.hpp
@@ -14,6 +14,7 @@ namespace DXR
 	public:
 	private:
 		bool m_use_msaa = true;
+		bool m_windowed_mode = true;
 		const UINT8 m_swapchain_buffer_count = 2;
 		Resolution m_resolution;
 		UINT16 m_refresh_rate;

--- a/DX_Renderer/Core/Components/Swapchain.hpp
+++ b/DX_Renderer/Core/Components/Swapchain.hpp
@@ -13,7 +13,6 @@ namespace DXR
 	{
 	public:
 	private:
-		bool m_use_msaa = true;
 		bool m_windowed_mode = true;
 		const UINT8 m_swapchain_buffer_count = 2;
 		Resolution m_resolution;

--- a/DX_Renderer/Core/Components/Swapchain.hpp
+++ b/DX_Renderer/Core/Components/Swapchain.hpp
@@ -28,8 +28,11 @@ namespace DXR
 		DescriptorHeap m_RTV_descriptor_heap;
 		DescriptorHeap m_DSV_descriptor_heap;
 		std::unique_ptr<DepthStencilBuffer> m_depth_stencil_buffer_resource;
+		UINT8 m_current_backbuffer = 0;
 	public:
 		IDXGISwapChain* operator->();
+		void SetViewport(GraphicsCommandList& commandList, Resolution& resolution, UINT xOffset = 0, UINT yOffset = 0);
+		void Present(GraphicsCommandList& commandList);
 	private:
 		Swapchain(GraphicsDevice& device, Window& window, UINT16 refreshRate, GraphicsCommandList& commandList);
 		Swapchain(GraphicsDevice& device, Window& window, UINT16 refreshRate, GraphicsCommandList& commandList, DXGI_FORMAT backbufferFormat);

--- a/DX_Renderer/Core/Components/Swapchain.hpp
+++ b/DX_Renderer/Core/Components/Swapchain.hpp
@@ -3,11 +3,13 @@
 #include <wrl.h>
 #include <dxgi.h>
 #include "../Windows Abstractions/Window.hpp"
-#include "GraphicsDevice.hpp"
+#include "Resource/DescriptorHeap.hpp"
 
 namespace DXR
 {
 	using namespace Microsoft;
+
+	struct GraphicsDevice;
 
 	struct Swapchain
 	{
@@ -20,11 +22,14 @@ namespace DXR
 		UINT16 m_refresh_rate;
 		WRL::ComPtr<IDXGISwapChain> m_swapchain;
 		DXGI_FORMAT m_backbuffer_format = DXGI_FORMAT::DXGI_FORMAT_R8G8B8A8_UNORM;
+		DescriptorHeap m_RTV_descriptor_heap;
+		DescriptorHeap m_DSV_descriptor_heap;
 	public:
 		IDXGISwapChain* operator->();
 	private:
 		Swapchain(GraphicsDevice& device, Window& window, UINT16 refreshRate);
 		Swapchain(GraphicsDevice& device, Window& window, UINT16 refreshRate, DXGI_FORMAT backbufferFormat);
 		inline void CreateSwapChain(GraphicsDevice& device, Window& window);
+		inline void CreateRenderTargetViews(GraphicsDevice& device);
 	};
 }

--- a/DX_Renderer/Core/Components/Swapchain.hpp
+++ b/DX_Renderer/Core/Components/Swapchain.hpp
@@ -1,15 +1,18 @@
 #pragma once
 
+#include <memory>
 #include <wrl.h>
 #include <dxgi.h>
 #include "../Windows Abstractions/Window.hpp"
 #include "Resource/DescriptorHeap.hpp"
+#include "Resource/DepthStencilBuffer.hpp"
 
 namespace DXR
 {
 	using namespace Microsoft;
 
 	struct GraphicsDevice;
+	struct GraphicsCommandList;
 
 	struct Swapchain
 	{
@@ -23,13 +26,16 @@ namespace DXR
 		WRL::ComPtr<IDXGISwapChain> m_swapchain;
 		DXGI_FORMAT m_backbuffer_format = DXGI_FORMAT::DXGI_FORMAT_R8G8B8A8_UNORM;
 		DescriptorHeap m_RTV_descriptor_heap;
+		DescriptorHeap m_DSV_descriptor_heap;
+		std::unique_ptr<DepthStencilBuffer> m_depth_stencil_buffer_resource;
 	public:
 		IDXGISwapChain* operator->();
 	private:
-		Swapchain(GraphicsDevice& device, Window& window, UINT16 refreshRate);
-		Swapchain(GraphicsDevice& device, Window& window, UINT16 refreshRate, DXGI_FORMAT backbufferFormat);
+		Swapchain(GraphicsDevice& device, Window& window, UINT16 refreshRate, GraphicsCommandList& commandList);
+		Swapchain(GraphicsDevice& device, Window& window, UINT16 refreshRate, GraphicsCommandList& commandList, DXGI_FORMAT backbufferFormat);
+		inline void Create(GraphicsDevice& device, Window& window, GraphicsCommandList& commandList);
 		inline void CreateSwapChain(GraphicsDevice& device, Window& window);
 		inline void CreateRenderTargetViews(GraphicsDevice& device) const;
-		inline void CreateDepthStencilBufferView(GraphicsDevice& device);
+		inline void CreateDepthStencilBufferView(GraphicsDevice& device, GraphicsCommandList& commandList);
 	};
 }

--- a/DX_Renderer/Core/Window.cpp
+++ b/DX_Renderer/Core/Window.cpp
@@ -1,0 +1,7 @@
+#include "Window.hpp"
+#include <Windows.h>
+
+void Window::test ()
+{
+    OutputDebugString("Test\n");
+}

--- a/DX_Renderer/Core/Window.cpp
+++ b/DX_Renderer/Core/Window.cpp
@@ -1,7 +1,0 @@
-#include "Window.hpp"
-#include <Windows.h>
-
-void Window::test ()
-{
-    OutputDebugString("Test\n");
-}

--- a/DX_Renderer/Core/Window.hpp
+++ b/DX_Renderer/Core/Window.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+class Window
+{
+public:
+    static void test();
+};
+
+

--- a/DX_Renderer/Core/Window.hpp
+++ b/DX_Renderer/Core/Window.hpp
@@ -1,9 +1,0 @@
-#pragma once
-
-class Window
-{
-public:
-    static void test();
-};
-
-

--- a/DX_Renderer/Core/Windows Abstractions/Window.cpp
+++ b/DX_Renderer/Core/Windows Abstractions/Window.cpp
@@ -1,23 +1,25 @@
 #include "Window.hpp"
+#include "../../Tooling/Log.hpp"
 
 namespace DXR
 {
 	LRESULT WindowMessageCallbackProcedure(HWND WindowHandle, UINT Message, WPARAM WParam, LPARAM LParam)
 	{
-		switch (Message)
+		switch(Message)
 		{
-		case WM_CLOSE:
-			current_window->HandleMessage(Message, WindowHandle, WParam, LParam);
-			DestroyWindow(WindowHandle);
-			break;
-		case WM_DESTROY:
-			current_window->HandleMessage(Message, WindowHandle, WParam, LParam);
-			PostQuitMessage(0);
-			break;
-		default:
-			if(current_window)
+			case WM_CLOSE:
 				current_window->HandleMessage(Message, WindowHandle, WParam, LParam);
-			return DefWindowProc(WindowHandle, Message, WParam, LParam);
+				DestroyWindow(WindowHandle);
+				current_window->ShouldContinue = false;
+				break;
+			case WM_DESTROY:
+				current_window->HandleMessage(Message, WindowHandle, WParam, LParam);
+				PostQuitMessage(0);
+				break;
+			default:
+				if(current_window)
+					current_window->HandleMessage(Message, WindowHandle, WParam, LParam);
+				return DefWindowProc(WindowHandle, Message, WParam, LParam);
 		}
 		return 0;
 	}
@@ -50,13 +52,9 @@ namespace DXR
 	void Window::UpdateWindow()
 	{
 		MSG message;
-		const BOOL updateStatus = GetMessage(&message, this->m_window_handle, 0, 0);
+		const BOOL updateStatus = PeekMessage(&message, this->m_window_handle, 0, 0, PM_REMOVE);
 		TranslateMessage(&message);
 		DispatchMessage(&message);
-		if(updateStatus == 0 || updateStatus == -1)
-		{
-			this->ShouldContinue = false;
-		}
 	}
 
 	void Window::RegisterWindowEventCallback(UINT message, const WindowEventMessageCallback& callback)
@@ -107,17 +105,17 @@ namespace DXR
 
 		// create the window
 		this->m_window_handle = CreateWindowEx(
-			WS_EX_CLIENTEDGE, 
+			WS_EX_CLIENTEDGE,
 			this->m_window_tittle.c_str(),
-			this->m_window_tittle.c_str(), 
-			WS_OVERLAPPEDWINDOW, 
+			this->m_window_tittle.c_str(),
+			WS_OVERLAPPEDWINDOW,
 			CW_USEDEFAULT, CW_USEDEFAULT,
-			this->m_window_resolution.Width, this->m_window_resolution.Height, 
-			nullptr, 
+			this->m_window_resolution.Width, this->m_window_resolution.Height,
 			nullptr,
-			this->m_instance, 
+			nullptr,
+			this->m_instance,
 			nullptr);
-		
+
 		//validate window creation
 		if(this->m_window_handle == nullptr)
 		{
@@ -131,4 +129,5 @@ namespace DXR
 
 		current_window = this;
 	}
+
 }

--- a/DX_Renderer/Core/Windows Abstractions/Window.cpp
+++ b/DX_Renderer/Core/Windows Abstractions/Window.cpp
@@ -54,7 +54,7 @@ namespace DXR
 	void Window::UpdateWindow()
 	{
 		MSG message;
-		const BOOL updateStatus = PeekMessage(&message, this->m_window_handle, 0, 0, PM_REMOVE);
+		const BOOL updateStatus = GetMessage(&message, this->m_window_handle, 0, 0);
 		TranslateMessage(&message);
 		DispatchMessage(&message);
 	}

--- a/DX_Renderer/Core/Windows Abstractions/Window.cpp
+++ b/DX_Renderer/Core/Windows Abstractions/Window.cpp
@@ -74,6 +74,11 @@ namespace DXR
 		}
 	}
 
+	Resolution Window::GetResolution() const
+	{
+		return this->m_window_resolution;
+	}
+
 	Window::Window(HINSTANCE Instance, int CmdShow, Resolution Resolution, const std::string& WindowTittle)
 		:m_instance(Instance), m_cmd_show(CmdShow), m_window_tittle(WindowTittle), m_window_resolution(Resolution)
 	{

--- a/DX_Renderer/Core/Windows Abstractions/Window.cpp
+++ b/DX_Renderer/Core/Windows Abstractions/Window.cpp
@@ -8,11 +8,13 @@ namespace DXR
 		switch(Message)
 		{
 			case WM_CLOSE:
+				INFO_LOG(L"Receibed WM_CLOSE Window Message\n");
 				current_window->HandleMessage(Message, WindowHandle, WParam, LParam);
 				DestroyWindow(WindowHandle);
 				current_window->ShouldContinue = false;
 				break;
 			case WM_DESTROY:
+				INFO_LOG(L"Receibed WM_DESTROY Window Message\n");
 				current_window->HandleMessage(Message, WindowHandle, WParam, LParam);
 				PostQuitMessage(0);
 				break;
@@ -59,6 +61,7 @@ namespace DXR
 
 	void Window::RegisterWindowEventCallback(UINT message, const WindowEventMessageCallback& callback)
 	{
+		INFO_LOG(L"Registering Window Message Event Callback Function\n");
 		this->m_registered_window_event_callbacks.emplace(message, callback);
 	}
 
@@ -80,6 +83,7 @@ namespace DXR
 	Window::Window(HINSTANCE Instance, int CmdShow, Resolution Resolution, const std::string& WindowTittle)
 		:m_instance(Instance), m_cmd_show(CmdShow), m_window_tittle(WindowTittle), m_window_resolution(Resolution)
 	{
+		INFO_LOG(L"Starting Windows Creation Procces\n");
 		// create the window class
 		WNDCLASSEX windowClass;
 		windowClass.cbSize = sizeof(WNDCLASSEX);
@@ -95,13 +99,16 @@ namespace DXR
 		windowClass.lpszClassName = this->m_window_tittle.c_str();
 		windowClass.hIconSm = LoadIcon(nullptr, IDI_APPLICATION);
 
+		INFO_LOG(L"Registering Window Class\n");
 		// register the window class
 		if(!RegisterClassEx(&windowClass))
 		{
+			ERROR_LOG(L"Failed To Register Window Class\n");
 			this->ShouldContinue = false;
 			MessageBox(nullptr, "Window Class Registration Failed!", "Error!", MB_ICONEXCLAMATION | MB_OK);
 			throw std::exception("Failed to create window class");
 		}
+		SUCCESS_LOG(L"Window Class Registered\n");
 
 		// create the window
 		this->m_window_handle = CreateWindowEx(
@@ -116,18 +123,22 @@ namespace DXR
 			this->m_instance,
 			nullptr);
 
+		INFO_LOG(L"Creating Win32 Window\n");
 		//validate window creation
 		if(this->m_window_handle == nullptr)
 		{
+			ERROR_LOG(L"Failed To Create Win32 Window\n");
 			this->ShouldContinue = false;
 			MessageBox(NULL, "Window Creation Failed!", "Error!", MB_ICONEXCLAMATION | MB_OK);
 			throw std::exception("Failed to Create Window!");
 		}
+		SUCCESS_LOG(L"Win32 Windows Created\n");
 
 		ShowWindow(this->m_window_handle, this->m_cmd_show);
 		::UpdateWindow(this->m_window_handle);
 
 		current_window = this;
+		SUCCESS_LOG(L"Window Creation Completed\n");
 	}
 
 }

--- a/DX_Renderer/Core/Windows Abstractions/Window.cpp
+++ b/DX_Renderer/Core/Windows Abstractions/Window.cpp
@@ -1,0 +1,110 @@
+#include "Window.hpp"
+
+namespace DXR
+{
+	LRESULT WindowMessageCallbackProcedure(HWND WindowHandle, UINT Message, WPARAM WParam, LPARAM LParam)
+	{
+		switch (Message)
+		{
+		case WM_CLOSE:
+			DestroyWindow(WindowHandle);
+			break;
+		case WM_DESTROY:
+			PostQuitMessage(0);
+			break;
+		default:
+			return DefWindowProc(WindowHandle, Message, WParam, LParam);
+		}
+		return 0;
+	}
+
+	Window* GetCurrentWindowHanlde()
+	{
+		return current_window;
+	}
+
+	Window* Window::GetCurrentWindowHandle()
+	{
+		return current_window;
+	}
+
+	HWND Window::GetWindowHandle()
+	{
+		return this->m_window_handle;
+	}
+
+	HINSTANCE Window::GetInstance()
+	{
+		return this->m_instance;
+	}
+
+	const std::string& Window::GetWindowTittle()
+	{
+		return this->m_window_tittle;
+	}
+
+	void Window::UpdateWindow()
+	{
+		MSG message;
+		const BOOL updateStatus = GetMessage(&message, this->m_window_handle, 0, 0);
+		TranslateMessage(&message);
+		DispatchMessage(&message);
+		if(updateStatus == 0 || updateStatus == -1)
+		{
+			this->ShouldContinue = false;
+		}
+	}
+
+	Window::Window(HINSTANCE Instance, int CmdShow, Resolution Resolution, const std::string& WindowTittle)
+		:m_instance(Instance), m_cmd_show(CmdShow), m_window_tittle(WindowTittle), m_window_resolution(Resolution)
+	{
+		// create the window class
+		WNDCLASSEX windowClass;
+		windowClass.cbSize = sizeof(WNDCLASSEX);
+		windowClass.style = 0;
+		windowClass.lpfnWndProc = WindowMessageCallbackProcedure;
+		windowClass.cbClsExtra = 0;
+		windowClass.cbWndExtra = 0;
+		windowClass.hInstance = this->m_instance;
+		windowClass.hIcon = LoadIcon(nullptr, IDI_APPLICATION);
+		windowClass.hCursor = LoadCursor(nullptr, IDC_ARROW);
+		windowClass.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
+		windowClass.lpszMenuName = nullptr;
+		windowClass.lpszClassName = this->m_window_tittle.c_str();
+		windowClass.hIconSm = LoadIcon(nullptr, IDI_APPLICATION);
+
+		// register the window class
+		if(!RegisterClassEx(&windowClass))
+		{
+			this->ShouldContinue = false;
+			MessageBox(nullptr, "Window Class Registration Failed!", "Error!", MB_ICONEXCLAMATION | MB_OK);
+			throw std::exception("Failed to create window class");
+		}
+
+		// create the window
+		this->m_window_handle = CreateWindowEx(
+			WS_EX_CLIENTEDGE, 
+			this->m_window_tittle.c_str(),
+			this->m_window_tittle.c_str(), 
+			WS_OVERLAPPEDWINDOW, 
+			CW_USEDEFAULT, CW_USEDEFAULT,
+			this->m_window_resolution.Width, this->m_window_resolution.Height, 
+			nullptr, 
+			nullptr,
+			this->m_instance, 
+			nullptr);
+		
+		//validate window creation
+		if(this->m_window_handle == nullptr)
+		{
+			this->ShouldContinue = false;
+			MessageBox(NULL, "Window Creation Failed!", "Error!", MB_ICONEXCLAMATION | MB_OK);
+			throw std::exception("Failed to Create Window!");
+		}
+
+		ShowWindow(this->m_window_handle, this->m_cmd_show);
+		::UpdateWindow(this->m_window_handle);
+
+		current_window = this;
+	}
+}

--- a/DX_Renderer/Core/Windows Abstractions/Window.hpp
+++ b/DX_Renderer/Core/Windows Abstractions/Window.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <string>
+#include <Windows.h>
+
+/**
+ * Defines a variable that should not be available outside of the translation module it was define in
+ */
+#define internal static
+
+namespace DXR
+{
+	internal LRESULT CALLBACK WindowMessageCallbackProcedure(HWND WindowHandle, UINT Message, WPARAM WParam, LPARAM LParam);
+	
+	struct Resolution
+	{
+		UINT16 Width;
+		UINT16 Height;
+	};
+	
+	struct Window
+	{
+		// public and private data fields
+	public:
+		bool ShouldContinue = true;
+	private:
+		HWND m_window_handle = nullptr;
+		HINSTANCE m_instance = nullptr;
+		int m_cmd_show = 0;
+
+		std::string m_window_tittle;
+		Resolution m_window_resolution = {};
+		
+		// public and private methods
+	public:
+		static Window* GetCurrentWindowHandle();
+		
+		Window(HINSTANCE Instance,int CmdShow,Resolution Resolution,const std::string& WindowTittle);
+		HWND GetWindowHandle();
+		HINSTANCE GetInstance();
+		const std::string& GetWindowTittle();
+		void UpdateWindow();
+	};
+
+	internal Window* current_window = nullptr;
+
+	Window* GetCurrentWindowHanlde();
+}
+

--- a/DX_Renderer/Core/Windows Abstractions/Window.hpp
+++ b/DX_Renderer/Core/Windows Abstractions/Window.hpp
@@ -53,6 +53,7 @@ namespace DXR
 		void UpdateWindow();
 		void RegisterWindowEventCallback(UINT message,const WindowEventMessageCallback& callback);
 		void HandleMessage(UINT Message, HWND windowHandle, WPARAM WParam, LPARAM LParam);
+		Resolution GetResolution() const;
 	};
 
 	internal Window* current_window = nullptr;

--- a/DX_Renderer/Core/Windows Abstractions/Window.hpp
+++ b/DX_Renderer/Core/Windows Abstractions/Window.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <string>
+#include <functional>
 #include <Windows.h>
+#include <unordered_map>
 
 /**
  * Defines a variable that should not be available outside of the translation module it was define in
@@ -17,6 +19,13 @@ namespace DXR
 		UINT16 Width;
 		UINT16 Height;
 	};
+
+	struct WindowEventMessageCallback
+	{
+		std::function<void(HWND, UINT, WPARAM, LPARAM)> callback;
+		UINT message;
+		std::string module;
+	};
 	
 	struct Window
 	{
@@ -30,6 +39,8 @@ namespace DXR
 
 		std::string m_window_tittle;
 		Resolution m_window_resolution = {};
+
+		std::unordered_multimap<UINT, WindowEventMessageCallback> m_registered_window_event_callbacks;
 		
 		// public and private methods
 	public:
@@ -40,10 +51,12 @@ namespace DXR
 		HINSTANCE GetInstance();
 		const std::string& GetWindowTittle();
 		void UpdateWindow();
+		void RegisterWindowEventCallback(UINT message,const WindowEventMessageCallback& callback);
+		void HandleMessage(UINT Message, HWND windowHandle, WPARAM WParam, LPARAM LParam);
 	};
 
 	internal Window* current_window = nullptr;
 
-	Window* GetCurrentWindowHanlde();
+	Window* GetCurrentWindowHandle();
 }
 

--- a/DX_Renderer/Core/Windows Abstractions/Window.hpp
+++ b/DX_Renderer/Core/Windows Abstractions/Window.hpp
@@ -41,12 +41,13 @@ namespace DXR
 		Resolution m_window_resolution = {};
 
 		std::unordered_multimap<UINT, WindowEventMessageCallback> m_registered_window_event_callbacks;
-		
+	
 		// public and private methods
 	public:
 		static Window* GetCurrentWindowHandle();
 		
 		Window(HINSTANCE Instance,int CmdShow,Resolution Resolution,const std::string& WindowTittle);
+		~Window() = default;
 		HWND GetWindowHandle();
 		HINSTANCE GetInstance();
 		const std::string& GetWindowTittle();

--- a/DX_Renderer/Tooling/Debug.cpp
+++ b/DX_Renderer/Tooling/Debug.cpp
@@ -25,6 +25,7 @@ namespace DXR
 		debugInterface->EnableDebugLayer();
 #endif
 	}
+
 	void Debug::CreateLogTerminal()
 	{
 #ifndef NDEBUG

--- a/DX_Renderer/Tooling/Debug.cpp
+++ b/DX_Renderer/Tooling/Debug.cpp
@@ -5,6 +5,7 @@
 namespace DXR
 {
 	Debug Debug::DebugInterface = {};
+	HANDLE Debug::ConsoleHandle = {};
 
 	Debug::Debug()
 	{
@@ -28,6 +29,7 @@ namespace DXR
 		FILE* input = freopen("CONIN$", "r", stdin);
 		FILE* output = freopen("CONOUT$", "w", stdout);
 		FILE* error = freopen("CONOUT$", "w", stderr);
+		Debug::ConsoleHandle = GetStdHandle(STD_OUTPUT_HANDLE);
 #endif
 	}
 }

--- a/DX_Renderer/Tooling/Debug.cpp
+++ b/DX_Renderer/Tooling/Debug.cpp
@@ -1,8 +1,16 @@
 #include "Debug.hpp"
 #include <d3d12sdklayers.h>
+#include <stdio.h>
 
 namespace DXR
 {
+	Debug Debug::DebugInterface = {};
+
+	void Debug::Log(std::string message)
+	{
+		printf(message.c_str());
+	}
+
 	Debug::Debug()
 	{
 		this->CreateLogTerminal();
@@ -11,7 +19,7 @@ namespace DXR
 
 	void Debug::EnableD3D12DebugLayer()
 	{
-#ifdef DEBUG
+#ifndef NDEBUG
 		WRL::ComPtr<ID3D12Debug> debugInterface;
 		D3D12GetDebugInterface(IID_PPV_ARGS(&debugInterface));
 		debugInterface->EnableDebugLayer();
@@ -19,11 +27,11 @@ namespace DXR
 	}
 	void Debug::CreateLogTerminal()
 	{
-#if DEBUG
+#ifndef NDEBUG
 		AllocConsole();
-		freopen("CONIN$", "r", stdin);
-		freopen("CONOUT$", "w", stdout);
-		freopen("CONOUT$", "w", stderr);
+		FILE* input = freopen("CONIN$", "r", stdin);
+		FILE* output = freopen("CONOUT$", "w", stdout);
+		FILE* error = freopen("CONOUT$", "w", stderr);
 #endif
 	}
 }

--- a/DX_Renderer/Tooling/Debug.cpp
+++ b/DX_Renderer/Tooling/Debug.cpp
@@ -6,11 +6,6 @@ namespace DXR
 {
 	Debug Debug::DebugInterface = {};
 
-	void Debug::Log(std::string message)
-	{
-		printf(message.c_str());
-	}
-
 	Debug::Debug()
 	{
 		this->CreateLogTerminal();

--- a/DX_Renderer/Tooling/Debug.cpp
+++ b/DX_Renderer/Tooling/Debug.cpp
@@ -1,0 +1,29 @@
+#include "Debug.hpp"
+#include <d3d12sdklayers.h>
+
+namespace DXR
+{
+	Debug::Debug()
+	{
+		this->CreateLogTerminal();
+		this->EnableD3D12DebugLayer();
+	}
+
+	void Debug::EnableD3D12DebugLayer()
+	{
+#ifdef DEBUG
+		WRL::ComPtr<ID3D12Debug> debugInterface;
+		D3D12GetDebugInterface(IID_PPV_ARGS(&debugInterface));
+		debugInterface->EnableDebugLayer();
+#endif
+	}
+	void Debug::CreateLogTerminal()
+	{
+#if DEBUG
+		AllocConsole();
+		freopen("CONIN$", "r", stdin);
+		freopen("CONOUT$", "w", stdout);
+		freopen("CONOUT$", "w", stderr);
+#endif
+	}
+}

--- a/DX_Renderer/Tooling/Debug.hpp
+++ b/DX_Renderer/Tooling/Debug.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <WRL.h>
+
+namespace DXR
+{
+
+	using namespace Microsoft;
+
+	struct Debug
+	{
+	public:
+		static Debug DebugInterface;
+	private:
+		Debug();
+		void EnableD3D12DebugLayer();
+		void CreateLogTerminal();
+	};
+}

--- a/DX_Renderer/Tooling/Debug.hpp
+++ b/DX_Renderer/Tooling/Debug.hpp
@@ -12,7 +12,6 @@ namespace DXR
 	{
 	public:
 		static Debug DebugInterface;
-		void Log(std::string message);
 	private:
 		Debug();
 		void EnableD3D12DebugLayer();

--- a/DX_Renderer/Tooling/Debug.hpp
+++ b/DX_Renderer/Tooling/Debug.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <WRL.h>
+#include <wrl.h>
+#include <string>
 
 namespace DXR
 {
@@ -11,6 +12,7 @@ namespace DXR
 	{
 	public:
 		static Debug DebugInterface;
+		void Log(std::string message);
 	private:
 		Debug();
 		void EnableD3D12DebugLayer();

--- a/DX_Renderer/Tooling/Debug.hpp
+++ b/DX_Renderer/Tooling/Debug.hpp
@@ -12,6 +12,7 @@ namespace DXR
 	{
 	public:
 		static Debug DebugInterface;
+		static HANDLE ConsoleHandle;
 	private:
 		Debug();
 		void EnableD3D12DebugLayer();

--- a/DX_Renderer/Tooling/Log.cpp
+++ b/DX_Renderer/Tooling/Log.cpp
@@ -12,7 +12,7 @@ namespace DXR
 	{
 		HANDLE hConsole = Debug::ConsoleHandle;
 		SetConsoleTextAttribute(hConsole, FOREGROUND_RED);
-		wprintf_s(L"[ERROR]@%s:%d::%s", file, line, message);
+		wprintf_s(L"[ERROR]@%s:%d=>%s", file, line, message);
 		SetConsoleTextAttribute(hConsole, FOREGROUND_BLUE|FOREGROUND_GREEN|FOREGROUND_RED);
 	}
 
@@ -20,7 +20,7 @@ namespace DXR
 	{
 		HANDLE hConsole = Debug::ConsoleHandle;
 		SetConsoleTextAttribute(hConsole, FOREGROUND_RED|FOREGROUND_GREEN);
-		wprintf_s(L"[WARNING]@%s:%d::%s", file, line, message);
+		wprintf_s(L"[WARNING]@%s:%d=>%s", file, line, message);
 		SetConsoleTextAttribute(hConsole, FOREGROUND_BLUE|FOREGROUND_GREEN|FOREGROUND_RED);
 	}
 
@@ -28,7 +28,7 @@ namespace DXR
 	{
 		HANDLE hConsole = Debug::ConsoleHandle;
 		SetConsoleTextAttribute(hConsole, FOREGROUND_GREEN);
-		wprintf_s(L"[SUCCESS]@%s:%d::%s", file, line, message);
+		wprintf_s(L"[SUCCESS]@%s:%d=>%s", file, line, message);
 		SetConsoleTextAttribute(hConsole, FOREGROUND_BLUE|FOREGROUND_GREEN|FOREGROUND_RED);
 	}
 
@@ -36,7 +36,7 @@ namespace DXR
 	{
 		HANDLE hConsole = Debug::ConsoleHandle;
 		SetConsoleTextAttribute(hConsole, FOREGROUND_BLUE|FOREGROUND_GREEN);
-		wprintf_s(L"[INFO]@%s:%d::%s", file, line, message);
+		wprintf_s(L"[INFO]@%s:%d=>%s", file, line, message);
 		SetConsoleTextAttribute(hConsole, FOREGROUND_BLUE|FOREGROUND_GREEN|FOREGROUND_RED);
 	}
 }

--- a/DX_Renderer/Tooling/Log.cpp
+++ b/DX_Renderer/Tooling/Log.cpp
@@ -1,21 +1,24 @@
 #include "Log.hpp"
 
-void LogError(wchar_t* file, unsigned int line, wchar_t* message)
+namespace DXR
 {
-	wprintf_s(L"[ERROR]@%s:%d::%s", file, line, message);
-}
+	void LogError(wchar_t* file, unsigned int line, wchar_t* message)
+	{
+		wprintf_s(L"[ERROR]@%s:%d::%s", file, line, message);
+	}
 
-void LogWarning(wchar_t* file, unsigned int line, wchar_t* message)
-{
-	wprintf_s(L"[WARNING]@%s:%d::%s", file, line, message);
-}
+	void LogWarning(wchar_t* file, unsigned int line, wchar_t* message)
+	{
+		wprintf_s(L"[WARNING]@%s:%d::%s", file, line, message);
+	}
 
-void LogSuccess(wchar_t* file, unsigned int line, wchar_t* message)
-{
-	wprintf_s(L"[SUCCESS]@%s:%d::%s", file, line, message);
-}
+	void LogSuccess(wchar_t* file, unsigned int line, wchar_t* message)
+	{
+		wprintf_s(L"[SUCCESS]@%s:%d::%s", file, line, message);
+	}
 
-void LogInfo(wchar_t* file, unsigned int line, wchar_t* message)
-{
-	wprintf_s(L"[INFO]@%s:%d::%s", file, line, message);
+	void LogInfo(wchar_t* file, unsigned int line, wchar_t* message)
+	{
+		wprintf_s(L"[INFO]@%s:%d::%s", file, line, message);
+	}
 }

--- a/DX_Renderer/Tooling/Log.cpp
+++ b/DX_Renderer/Tooling/Log.cpp
@@ -1,0 +1,21 @@
+#include "Log.hpp"
+
+void LogError(wchar_t* file, unsigned int line, wchar_t* message)
+{
+	wprintf_s(L"[ERROR]@%s:%d::%s", file, line, message);
+}
+
+void LogWarning(wchar_t* file, unsigned int line, wchar_t* message)
+{
+	wprintf_s(L"[WARNING]@%s:%d::%s", file, line, message);
+}
+
+void LogSuccess(wchar_t* file, unsigned int line, wchar_t* message)
+{
+	wprintf_s(L"[SUCCESS]@%s:%d::%s", file, line, message);
+}
+
+void LogInfo(wchar_t* file, unsigned int line, wchar_t* message)
+{
+	wprintf_s(L"[INFO]@%s:%d::%s", file, line, message);
+}

--- a/DX_Renderer/Tooling/Log.cpp
+++ b/DX_Renderer/Tooling/Log.cpp
@@ -1,24 +1,42 @@
 #include "Log.hpp"
+#include <string>
+#include <wrl.h>
+#include "Debug.hpp"
 
 namespace DXR
 {
+
+	static HANDLE consoleHandle;
+	
 	void LogError(wchar_t* file, unsigned int line, wchar_t* message)
 	{
+		HANDLE hConsole = Debug::ConsoleHandle;
+		SetConsoleTextAttribute(hConsole, FOREGROUND_RED);
 		wprintf_s(L"[ERROR]@%s:%d::%s", file, line, message);
+		SetConsoleTextAttribute(hConsole, FOREGROUND_BLUE|FOREGROUND_GREEN|FOREGROUND_RED);
 	}
 
 	void LogWarning(wchar_t* file, unsigned int line, wchar_t* message)
 	{
+		HANDLE hConsole = Debug::ConsoleHandle;
+		SetConsoleTextAttribute(hConsole, FOREGROUND_RED|FOREGROUND_GREEN);
 		wprintf_s(L"[WARNING]@%s:%d::%s", file, line, message);
+		SetConsoleTextAttribute(hConsole, FOREGROUND_BLUE|FOREGROUND_GREEN|FOREGROUND_RED);
 	}
 
 	void LogSuccess(wchar_t* file, unsigned int line, wchar_t* message)
 	{
+		HANDLE hConsole = Debug::ConsoleHandle;
+		SetConsoleTextAttribute(hConsole, FOREGROUND_GREEN);
 		wprintf_s(L"[SUCCESS]@%s:%d::%s", file, line, message);
+		SetConsoleTextAttribute(hConsole, FOREGROUND_BLUE|FOREGROUND_GREEN|FOREGROUND_RED);
 	}
 
 	void LogInfo(wchar_t* file, unsigned int line, wchar_t* message)
 	{
+		HANDLE hConsole = Debug::ConsoleHandle;
+		SetConsoleTextAttribute(hConsole, FOREGROUND_BLUE|FOREGROUND_GREEN);
 		wprintf_s(L"[INFO]@%s:%d::%s", file, line, message);
+		SetConsoleTextAttribute(hConsole, FOREGROUND_BLUE|FOREGROUND_GREEN|FOREGROUND_RED);
 	}
 }

--- a/DX_Renderer/Tooling/Log.hpp
+++ b/DX_Renderer/Tooling/Log.hpp
@@ -1,12 +1,15 @@
 #include "Debug.hpp"
 
-void LogError(wchar_t* file, unsigned int line, wchar_t* message);
-void LogWarning(wchar_t* file, unsigned int line, wchar_t* message);
-void LogSuccess(wchar_t* file, unsigned int line, wchar_t* message);
-void LogInfo(wchar_t* file, unsigned int line, wchar_t* message);
+namespace DXR
+{
+	void LogError(wchar_t* file, unsigned int line, wchar_t* message);
+	void LogWarning(wchar_t* file, unsigned int line, wchar_t* message);
+	void LogSuccess(wchar_t* file, unsigned int line, wchar_t* message);
+	void LogInfo(wchar_t* file, unsigned int line, wchar_t* message);
 
 #define ERROR_LOG(Message) LogError(__FILEW__,__LINE__,Message)
 #define WARNING_LOG(Message) LogWarning(__FILEW__,__LINE__,Message)
 #define SUCCESS_LOG(Message) LogWarning(__FILEW__,__LINE__,Message)
 #define INFO_LOG(Message) LogWarning(__FILEW__,__LINE__,Message)
 #define LOG(Message) wprintf_s(Message)
+}

--- a/DX_Renderer/Tooling/Log.hpp
+++ b/DX_Renderer/Tooling/Log.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include "Debug.hpp"
 
 namespace DXR

--- a/DX_Renderer/Tooling/Log.hpp
+++ b/DX_Renderer/Tooling/Log.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include "Debug.hpp"
 
 namespace DXR
 {
@@ -10,9 +9,9 @@ namespace DXR
 
 #define __FILENAME__ (wcsrchr(__FILEW__, '\\') ? wcsrchr(__FILEW__, '\\') + 1 : __FILEW__)
 
-#define ERROR_LOG(Message) LogError(__FILENAME__,__LINE__,Message)
-#define WARNING_LOG(Message) LogWarning(__FILENAME__,__LINE__,Message)
-#define SUCCESS_LOG(Message) LogSuccess(__FILENAME__,__LINE__,Message)
-#define INFO_LOG(Message) LogInfo(__FILENAME__,__LINE__,Message)
+#define ERROR_LOG(Message) DXR::LogError(__FILENAME__,__LINE__,Message)
+#define WARNING_LOG(Message) DXR::LogWarning(__FILENAME__,__LINE__,Message)
+#define SUCCESS_LOG(Message) DXR::LogSuccess(__FILENAME__,__LINE__,Message)
+#define INFO_LOG(Message) DXR::LogInfo(__FILENAME__,__LINE__,Message)
 #define LOG(Message) wprintf_s(Message)
 }

--- a/DX_Renderer/Tooling/Log.hpp
+++ b/DX_Renderer/Tooling/Log.hpp
@@ -1,0 +1,11 @@
+#include "Debug.hpp"
+#include <string>
+
+#define internal static
+
+void LogError(wchar_t* file, unsigned int line, wchar_t* message)
+{
+	wprintf_s(L"[ERROR]@%s:%d::%s", file, line, message);
+}
+
+#define ERROR_LOG(Message) LogError(__FILEW__,__LINE__,Message)

--- a/DX_Renderer/Tooling/Log.hpp
+++ b/DX_Renderer/Tooling/Log.hpp
@@ -1,11 +1,12 @@
 #include "Debug.hpp"
-#include <string>
 
-#define internal static
-
-void LogError(wchar_t* file, unsigned int line, wchar_t* message)
-{
-	wprintf_s(L"[ERROR]@%s:%d::%s", file, line, message);
-}
+void LogError(wchar_t* file, unsigned int line, wchar_t* message);
+void LogWarning(wchar_t* file, unsigned int line, wchar_t* message);
+void LogSuccess(wchar_t* file, unsigned int line, wchar_t* message);
+void LogInfo(wchar_t* file, unsigned int line, wchar_t* message);
 
 #define ERROR_LOG(Message) LogError(__FILEW__,__LINE__,Message)
+#define WARNING_LOG(Message) LogWarning(__FILEW__,__LINE__,Message)
+#define SUCCESS_LOG(Message) LogWarning(__FILEW__,__LINE__,Message)
+#define INFO_LOG(Message) LogWarning(__FILEW__,__LINE__,Message)
+#define LOG(Message) wprintf_s(Message)

--- a/DX_Renderer/Tooling/Log.hpp
+++ b/DX_Renderer/Tooling/Log.hpp
@@ -8,9 +8,11 @@ namespace DXR
 	void LogSuccess(wchar_t* file, unsigned int line, wchar_t* message);
 	void LogInfo(wchar_t* file, unsigned int line, wchar_t* message);
 
-#define ERROR_LOG(Message) LogError(__FILEW__,__LINE__,Message)
-#define WARNING_LOG(Message) LogWarning(__FILEW__,__LINE__,Message)
-#define SUCCESS_LOG(Message) LogWarning(__FILEW__,__LINE__,Message)
-#define INFO_LOG(Message) LogWarning(__FILEW__,__LINE__,Message)
+#define __FILENAME__ (wcsrchr(__FILEW__, '\\') ? wcsrchr(__FILEW__, '\\') + 1 : __FILEW__)
+
+#define ERROR_LOG(Message) LogError(__FILENAME__,__LINE__,Message)
+#define WARNING_LOG(Message) LogWarning(__FILENAME__,__LINE__,Message)
+#define SUCCESS_LOG(Message) LogSuccess(__FILENAME__,__LINE__,Message)
+#define INFO_LOG(Message) LogInfo(__FILENAME__,__LINE__,Message)
 #define LOG(Message) wprintf_s(Message)
 }

--- a/DX_Renderer/Tooling/Validate.cpp
+++ b/DX_Renderer/Tooling/Validate.cpp
@@ -1,0 +1,12 @@
+#include "Validate.hpp"
+
+namespace DXR
+{
+	wchar_t* FormatMessage(HRESULT res)
+	{
+		LPWSTR messageBuffer = nullptr;
+		size_t size = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+			NULL, res, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, NULL);
+		return messageBuffer;
+	}
+}

--- a/DX_Renderer/Tooling/Validate.hpp
+++ b/DX_Renderer/Tooling/Validate.hpp
@@ -1,9 +1,15 @@
 #pragma once
 
-#ifdef DEBUG
+#include "Debug.hpp"
+
+#ifndef NDEBUG
 #define DXCall(x)\
 	HRESULT res = x;\
-	
+	if(res < 0)\
+	{\
+		DXR::Debug::DebugInterface.Log(__FILE__); \
+			__debugbreak();\
+	}
 #else
 #define DXCall(x) x;
 #endif

--- a/DX_Renderer/Tooling/Validate.hpp
+++ b/DX_Renderer/Tooling/Validate.hpp
@@ -1,14 +1,23 @@
 #pragma once
 
-#include "Debug.hpp"
+#include "Log.hpp"
+
+wchar_t* FormatMessage(HRESULT res)
+{
+	LPWSTR messageBuffer = nullptr;
+	size_t size = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+		NULL, res, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, NULL);
+	return messageBuffer;
+}
 
 #ifndef NDEBUG
 #define DXCall(x)\
 	HRESULT res = x;\
 	if(res < 0)\
 	{\
-		DXR::Debug::DebugInterface.Log(__FILE__); \
-			__debugbreak();\
+		ERROR_LOG(FormatMessage(res)); \
+		__debugbreak();\
+		exit(-1);\
 	}
 #else
 #define DXCall(x) x;

--- a/DX_Renderer/Tooling/Validate.hpp
+++ b/DX_Renderer/Tooling/Validate.hpp
@@ -1,16 +1,9 @@
 #pragma once
-
 #include "Log.hpp"
 
 namespace DXR
 {
-	wchar_t* FormatMessage(HRESULT res)
-	{
-		LPWSTR messageBuffer = nullptr;
-		size_t size = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-			NULL, res, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, NULL);
-		return messageBuffer;
-	}
+	wchar_t* FormatMessage(HRESULT res);
 
 #ifndef NDEBUG
 #define DXCall(x)\

--- a/DX_Renderer/Tooling/Validate.hpp
+++ b/DX_Renderer/Tooling/Validate.hpp
@@ -12,10 +12,12 @@ wchar_t* FormatMessage(HRESULT res)
 
 #ifndef NDEBUG
 #define DXCall(x)\
-	HRESULT res = x;\
-	if(res < 0)\
+	HRESULT result_code = x;\
+	if(result_code < 0)\
 	{\
-		ERROR_LOG(FormatMessage(res)); \
+		wchar_t* error_message = FormatMessage(result_code);\
+		ERROR_LOG(error_message); \
+		free(error_message);\
 		__debugbreak();\
 		exit(-1);\
 	}

--- a/DX_Renderer/Tooling/Validate.hpp
+++ b/DX_Renderer/Tooling/Validate.hpp
@@ -2,13 +2,15 @@
 
 #include "Log.hpp"
 
-wchar_t* FormatMessage(HRESULT res)
+namespace DXR
 {
-	LPWSTR messageBuffer = nullptr;
-	size_t size = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-		NULL, res, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, NULL);
-	return messageBuffer;
-}
+	wchar_t* FormatMessage(HRESULT res)
+	{
+		LPWSTR messageBuffer = nullptr;
+		size_t size = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+			NULL, res, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, NULL);
+		return messageBuffer;
+	}
 
 #ifndef NDEBUG
 #define DXCall(x)\
@@ -23,3 +25,4 @@ wchar_t* FormatMessage(HRESULT res)
 #else
 #define DXCall(x) x;
 #endif
+}

--- a/DX_Renderer/Tooling/Validate.hpp
+++ b/DX_Renderer/Tooling/Validate.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <wrl.h>
 #include "Log.hpp"
 
 namespace DXR

--- a/DX_Renderer/Tooling/Validate.hpp
+++ b/DX_Renderer/Tooling/Validate.hpp
@@ -19,7 +19,6 @@ wchar_t* FormatMessage(HRESULT res)
 		ERROR_LOG(error_message); \
 		free(error_message);\
 		__debugbreak();\
-		exit(-1);\
 	}
 #else
 #define DXCall(x) x;

--- a/DX_Renderer/Tooling/Validate.hpp
+++ b/DX_Renderer/Tooling/Validate.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#ifdef DEBUG
+#define DXCall(x)\
+	HRESULT res = x;\
+	
+#else
+#define DXCall(x) x;
+#endif

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -12,13 +12,6 @@ int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	freopen("CONOUT$", "w", stderr);
 
 	DXR::GraphicsDevice device;
-	auto devices = device.GetGraphicsAdapterList();
-	for (auto& adapter : devices)
-	{
-		DXGI_ADAPTER_DESC description;
-		adapter->GetDesc(&description);
-		wprintf(L"%s\n", description.Description);
-	}
 	
 	DXR::Window window{ hInstance,nCmdShow,{1280,720},"DX Renderer" };
 	while(window.ShouldContinue)

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -12,6 +12,7 @@ int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	DXR::Fence fence = device.CreateFence(0);
 	DXR::GraphicsCommandQueue queue{device};
 	DXR::GraphicsCommandList commandList{device};
+	device.CheckSupportedMSAALevels(DXGI_FORMAT_R8G8B8A8_UNORM);
 
 	DXR::Window window{ hInstance,nCmdShow,{1280,720},"DX Renderer" };
 	while(window.ShouldContinue)

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -15,7 +15,7 @@ int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	DXR::GraphicsDevice device;
 	DXR::Fence fence = device.CreateFence(0);
 	DXR::GraphicsCommandList commandList =  device.CreateGraphicsCommandList();
-	DXR::Swapchain swapchain = device.CreateSwapchain(window,60);
+	DXR::Swapchain swapchain = device.CreateSwapchain(window,60,commandList);
 	
 	while(window.ShouldContinue)
 	{

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -17,7 +17,7 @@ int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	DXR::GraphicsCommandList commandList =  device.CreateGraphicsCommandList();
 	DXR::Swapchain swapchain = device.CreateSwapchain(window,60);
 	//DXR::DescriptorHeap heap = device.CreateRenderTargetViewDescriptorHeap(2);
-
+	
 	while(window.ShouldContinue)
 	{
 		//swapchain->Present(0,0);

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -1,5 +1,6 @@
 #include <Windows.h>
 #include "Core/Windows Abstractions/Window.hpp"
+#include "Core/Components/GraphicsDevice.hpp"
 
 int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
                    LPSTR lpCmdLine, int nCmdShow)
@@ -9,10 +10,13 @@ int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	freopen("CONIN$", "r", stdin);
 	freopen("CONOUT$", "w", stdout);
 	freopen("CONOUT$", "w", stderr);
+
+	DXR::GraphicsDevice device;
 	
 	DXR::Window window{ hInstance,nCmdShow,{1280,720},"DX Renderer" };
 	while(window.ShouldContinue)
 	{
+		device.GetGraphicsAdapterList();
 		window.UpdateWindow();
 	}
 	return 0;

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -4,17 +4,18 @@
 #include "Core/Components/Fence.hpp"
 #include "Core/Components/Command Queue/GraphicsCommandQueue.hpp"
 #include "Core/Components/Command List/GraphicsCommandList.hpp"
+#include "Core/Components/Swapchain.hpp"
 
 int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
                    LPSTR lpCmdLine, int nCmdShow)
 {
+	DXR::Window window{hInstance,nCmdShow,{1280,720},"DX Renderer"};
+
 	DXR::GraphicsDevice device;
 	DXR::Fence fence = device.CreateFence(0);
-	DXR::GraphicsCommandQueue queue{device};
 	DXR::GraphicsCommandList commandList{device};
-	device.CheckSupportedMSAALevels(DXGI_FORMAT_R8G8B8A8_UNORM);
+	DXR::Swapchain swapchain{device,window,60};
 
-	DXR::Window window{ hInstance,nCmdShow,{1280,720},"DX Renderer" };
 	while(window.ShouldContinue)
 	{
 		window.UpdateWindow();

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -4,22 +4,36 @@
 #include "Core/Components/Fence.hpp"
 #include "Core/Components/Command List/GraphicsCommandList.hpp"
 #include "Core/Components/Swapchain.hpp"
-#include "Tooling/Validate.hpp"
+#include "Tooling/Log.hpp"
+#include <thread>
 
-int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
-                   LPSTR lpCmdLine, int nCmdShow)
+void MainRenderThread(DXR::Window& window)
 {
-	DXR::Window window{hInstance,nCmdShow,{1280,720},"DX Renderer"};
 
 	DXR::GraphicsDevice device;
 	DXR::Fence fence = device.CreateFence(0);
-	DXR::GraphicsCommandList commandList =  device.CreateGraphicsCommandList();
-	DXR::Swapchain swapchain = device.CreateSwapchain(window,60,commandList);
-	
+	DXR::GraphicsCommandList commandList = device.CreateGraphicsCommandList();
+	DXR::Swapchain swapchain = device.CreateSwapchain(window, 60, commandList);
+
 	while(window.ShouldContinue)
 	{
 		swapchain.Present(commandList);
+	}
+
+}
+
+int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
+	LPSTR lpCmdLine, int nCmdShow)
+{
+	DXR::Window window{hInstance,nCmdShow,{1280,720},"DX Renderer"};
+
+	std::thread main_render_thread(MainRenderThread,std::ref(window));
+
+	while(window.ShouldContinue)
+	{
 		window.UpdateWindow();
 	}
+
+	main_render_thread.join();
 	return 0;
 }

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -1,7 +1,7 @@
 #include <Windows.h>
 #include "Core/Windows Abstractions/Window.hpp"
 
-int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
+int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
                    LPSTR lpCmdLine, int nCmdShow)
 {
 	DXR::Window window{ hInstance,nCmdShow,{1280,720},"DX Renderer" };

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -4,6 +4,7 @@
 #include "Core/Components/Fence.hpp"
 #include "Core/Components/Command List/GraphicsCommandList.hpp"
 #include "Core/Components/Swapchain.hpp"
+#include "Core/Components/Resource/DescriptorHeap.hpp"
 #include "Tooling/Log.hpp"
 
 int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
@@ -15,11 +16,11 @@ int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	DXR::Fence fence = device.CreateFence(0);
 	DXR::GraphicsCommandList commandList =  device.CreateGraphicsCommandList();
 	DXR::Swapchain swapchain = device.CreateSwapchain(window,60);
+	//DXR::DescriptorHeap heap = device.CreateRenderTargetViewDescriptorHeap(2);
 
 	while(window.ShouldContinue)
 	{
-		DXR::INFO_LOG(L"UPDATE\n");
-		swapchain->Present(0,0);
+		//swapchain->Present(0,0);
 		window.UpdateWindow();
 	}
 	return 0;

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -16,7 +16,6 @@ int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	DXR::Fence fence = device.CreateFence(0);
 	DXR::GraphicsCommandList commandList =  device.CreateGraphicsCommandList();
 	DXR::Swapchain swapchain = device.CreateSwapchain(window,60);
-	//DXR::DescriptorHeap heap = device.CreateRenderTargetViewDescriptorHeap(2);
 	
 	while(window.ShouldContinue)
 	{

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -2,7 +2,6 @@
 #include "Core/Windows Abstractions/Window.hpp"
 #include "Core/Components/GraphicsDevice.hpp"
 #include "Core/Components/Fence.hpp"
-#include "Core/Components/Command Queue/GraphicsCommandQueue.hpp"
 #include "Core/Components/Command List/GraphicsCommandList.hpp"
 #include "Core/Components/Swapchain.hpp"
 
@@ -13,8 +12,8 @@ int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 
 	DXR::GraphicsDevice device;
 	DXR::Fence fence = device.CreateFence(0);
-	DXR::GraphicsCommandList commandList{device};
-	DXR::Swapchain swapchain{device,window,60};
+	DXR::GraphicsCommandList commandList =  device.CreateGraphicsCommandList();
+	DXR::Swapchain swapchain = device.CreateSwapchain(window,60);
 
 	while(window.ShouldContinue)
 	{

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -12,11 +12,17 @@ int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	freopen("CONOUT$", "w", stderr);
 
 	DXR::GraphicsDevice device;
+	auto devices = device.GetGraphicsAdapterList();
+	for (auto& adapter : devices)
+	{
+		DXGI_ADAPTER_DESC description;
+		adapter->GetDesc(&description);
+		wprintf(L"%s\n", description.Description);
+	}
 	
 	DXR::Window window{ hInstance,nCmdShow,{1280,720},"DX Renderer" };
 	while(window.ShouldContinue)
 	{
-		device.GetGraphicsAdapterList();
 		window.UpdateWindow();
 	}
 	return 0;

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -11,7 +11,7 @@ int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 {
 	DXR::Window window{hInstance,nCmdShow,{1280,720},"DX Renderer"};
 
-	DXR::GraphicsDevice device;
+	DXR::GraphicsDevice device{1};
 	DXR::Fence fence = device.CreateFence(0);
 	DXR::GraphicsCommandList commandList{device};
 	DXR::Swapchain swapchain{device,window,60};

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -5,7 +5,7 @@
 int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
                    LPSTR lpCmdLine, int nCmdShow)
 {
-	DXR::GraphicsDevice device = { 1 };
+	DXR::GraphicsDevice device;
 	
 	DXR::Window window{ hInstance,nCmdShow,{1280,720},"DX Renderer" };
 	while(window.ShouldContinue)

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -5,13 +5,7 @@
 int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
                    LPSTR lpCmdLine, int nCmdShow)
 {
-	// debug console and shit
-	AllocConsole();
-	freopen("CONIN$", "r", stdin);
-	freopen("CONOUT$", "w", stdout);
-	freopen("CONOUT$", "w", stderr);
-
-	DXR::GraphicsDevice device;
+	DXR::GraphicsDevice device = { 1 };
 	
 	DXR::Window window{ hInstance,nCmdShow,{1280,720},"DX Renderer" };
 	while(window.ShouldContinue)

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -4,6 +4,12 @@
 int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
                    LPSTR lpCmdLine, int nCmdShow)
 {
+	// debug console and shit
+	AllocConsole();
+	freopen("CONIN$", "r", stdin);
+	freopen("CONOUT$", "w", stdout);
+	freopen("CONOUT$", "w", stderr);
+	
 	DXR::Window window{ hInstance,nCmdShow,{1280,720},"DX Renderer" };
 	while(window.ShouldContinue)
 	{

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -4,8 +4,7 @@
 #include "Core/Components/Fence.hpp"
 #include "Core/Components/Command List/GraphicsCommandList.hpp"
 #include "Core/Components/Swapchain.hpp"
-#include "Core/Components/Resource/DescriptorHeap.hpp"
-#include "Tooling/Log.hpp"
+#include "Tooling/Validate.hpp"
 
 int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
                    LPSTR lpCmdLine, int nCmdShow)
@@ -19,7 +18,7 @@ int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	
 	while(window.ShouldContinue)
 	{
-		//swapchain->Present(0,0);
+		swapchain.Present(commandList);
 		window.UpdateWindow();
 	}
 	return 0;

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -15,6 +15,9 @@ void MainDirectXThread(DXR::Window& window)
 	DXR::GraphicsCommandList commandList = device.CreateGraphicsCommandList();
 	DXR::Swapchain swapchain = device.CreateSwapchain(window, 60, commandList);
 
+	commandList->Close();
+	device.GetGraphicsCommandQueue()->Flush(fence);
+	
 	while(window.ShouldContinue)
 	{
 		swapchain.Present(commandList);

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -4,6 +4,7 @@
 #include "Core/Components/Fence.hpp"
 #include "Core/Components/Command List/GraphicsCommandList.hpp"
 #include "Core/Components/Swapchain.hpp"
+#include "Tooling/Log.hpp"
 
 int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
                    LPSTR lpCmdLine, int nCmdShow)
@@ -17,6 +18,8 @@ int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 
 	while(window.ShouldContinue)
 	{
+		DXR::INFO_LOG(L"UPDATE\n");
+		swapchain->Present(0,0);
 		window.UpdateWindow();
 	}
 	return 0;

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -1,12 +1,14 @@
 #include <Windows.h>
 #include "Core/Windows Abstractions/Window.hpp"
 #include "Core/Components/GraphicsDevice.hpp"
+#include "Core/Components/Fence.hpp"
 
 int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
                    LPSTR lpCmdLine, int nCmdShow)
 {
 	DXR::GraphicsDevice device;
-	
+	DXR::Fence fence = device.CreateFence(0);
+
 	DXR::Window window{ hInstance,nCmdShow,{1280,720},"DX Renderer" };
 	while(window.ShouldContinue)
 	{

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -11,7 +11,7 @@ int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 {
 	DXR::Window window{hInstance,nCmdShow,{1280,720},"DX Renderer"};
 
-	DXR::GraphicsDevice device{1};
+	DXR::GraphicsDevice device;
 	DXR::Fence fence = device.CreateFence(0);
 	DXR::GraphicsCommandList commandList{device};
 	DXR::Swapchain swapchain{device,window,60};

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -7,9 +7,9 @@
 #include "Tooling/Log.hpp"
 #include <thread>
 
-void MainRenderThread(DXR::Window& window)
+void MainDirectXThread(DXR::Window& window)
 {
-
+	SUCCESS_LOG(L"Main DirectX12 Thread Started\n");
 	DXR::GraphicsDevice device;
 	DXR::Fence fence = device.CreateFence(0);
 	DXR::GraphicsCommandList commandList = device.CreateGraphicsCommandList();
@@ -27,13 +27,13 @@ int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 {
 	DXR::Window window{hInstance,nCmdShow,{1280,720},"DX Renderer"};
 
-	std::thread main_render_thread(MainRenderThread,std::ref(window));
+	std::thread main_dx12_thread(MainDirectXThread,std::ref(window));
 
 	while(window.ShouldContinue)
 	{
 		window.UpdateWindow();
 	}
 
-	main_render_thread.join();
+	main_dx12_thread.join();
 	return 0;
 }

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -2,12 +2,16 @@
 #include "Core/Windows Abstractions/Window.hpp"
 #include "Core/Components/GraphicsDevice.hpp"
 #include "Core/Components/Fence.hpp"
+#include "Core/Components/Command Queue/GraphicsCommandQueue.hpp"
+#include "Core/Components/Command List/GraphicsCommandList.hpp"
 
 int WINAPI CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
                    LPSTR lpCmdLine, int nCmdShow)
 {
 	DXR::GraphicsDevice device;
 	DXR::Fence fence = device.CreateFence(0);
+	DXR::GraphicsCommandQueue queue{device};
+	DXR::GraphicsCommandList commandList{device};
 
 	DXR::Window window{ hInstance,nCmdShow,{1280,720},"DX Renderer" };
 	while(window.ShouldContinue)

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -1,80 +1,13 @@
 #include <Windows.h>
-#include "Core/Window.hpp"
-
-const char g_szClassName[] = "myWindowClass";
-
-// Step 4: the Window Procedure
-LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
-{
-    switch(msg)
-    {
-        case WM_CLOSE:
-            DestroyWindow(hwnd);
-            break;
-        case WM_DESTROY:
-            PostQuitMessage(0);
-            break;
-        default:
-            return DefWindowProc(hwnd, msg, wParam, lParam);
-    }
-    return 0;
-}
+#include "Core/Windows Abstractions/Window.hpp"
 
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
                    LPSTR lpCmdLine, int nCmdShow)
 {
-    WNDCLASSEX wc;
-    HWND hwnd;
-    MSG Msg;
-
-    //Step 1: Registering the Window Class
-    wc.cbSize        = sizeof(WNDCLASSEX);
-    wc.style         = 0;
-    wc.lpfnWndProc   = WndProc;
-    wc.cbClsExtra    = 0;
-    wc.cbWndExtra    = 0;
-    wc.hInstance     = hInstance;
-    wc.hIcon         = LoadIcon(NULL, IDI_APPLICATION);
-    wc.hCursor       = LoadCursor(NULL, IDC_ARROW);
-    wc.hbrBackground = (HBRUSH)(COLOR_WINDOW+1);
-    wc.lpszMenuName  = NULL;
-    wc.lpszClassName = g_szClassName;
-    wc.hIconSm       = LoadIcon(NULL, IDI_APPLICATION);
-
-    if(!RegisterClassEx(&wc))
-    {
-        MessageBox(NULL, "Window Registration Failed!", "Error!",
-                   MB_ICONEXCLAMATION | MB_OK);
-        return 0;
-    }
-
-    // Step 2: Creating the Window
-    hwnd = CreateWindowEx(
-            WS_EX_CLIENTEDGE,
-            g_szClassName,
-            "The title of my window",
-            WS_OVERLAPPEDWINDOW,
-            CW_USEDEFAULT, CW_USEDEFAULT, 240, 120,
-            NULL, NULL, hInstance, NULL);
-
-    if(hwnd == NULL)
-    {
-        MessageBox(NULL, "Window Creation Failed!", "Error!",
-                   MB_ICONEXCLAMATION | MB_OK);
-        return 0;
-    }
-
-    ShowWindow(hwnd, nCmdShow);
-    UpdateWindow(hwnd);
-
-    Window::test ();
-
-    // Step 3: The Message Loop
-    while(GetMessage(&Msg, NULL, 0, 0) > 0)
-    {
-        TranslateMessage(&Msg);
-        DispatchMessage(&Msg);
-    }
-
-    return Msg.wParam;
+	DXR::Window window{ hInstance,nCmdShow,{1280,720},"DX Renderer" };
+	while(window.ShouldContinue)
+	{
+		window.UpdateWindow();
+	}
+	return 0;
 }

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -1,4 +1,5 @@
-#include <windows.h>
+#include <Windows.h>
+#include "Core/Window.hpp"
 
 const char g_szClassName[] = "myWindowClass";
 
@@ -65,6 +66,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 
     ShowWindow(hwnd, nCmdShow);
     UpdateWindow(hwnd);
+
+    Window::test ();
 
     // Step 3: The Message Loop
     while(GetMessage(&Msg, NULL, 0, 0) > 0)

--- a/DX_Renderer/main.cpp
+++ b/DX_Renderer/main.cpp
@@ -16,6 +16,8 @@ void MainDirectXThread(DXR::Window& window)
 	DXR::Swapchain swapchain = device.CreateSwapchain(window, 60, commandList);
 
 	commandList->Close();
+	ID3D12CommandList* commandLists[] = {commandList.GetRAWInterface()};
+	(*device.GetGraphicsCommandQueue())->ExecuteCommandLists(1,commandLists);
 	device.GetGraphicsCommandQueue()->Flush(fence);
 	
 	while(window.ShouldContinue)

--- a/Logger.hpp
+++ b/Logger.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+struct Logger
+{
+};

--- a/Logger.hpp
+++ b/Logger.hpp
@@ -1,5 +1,0 @@
-#pragma once
-
-struct Logger
-{
-};


### PR DESCRIPTION
With this pull request the Direct3D initialization sequence was abstracted as well as the windows window class, some tools were also created.

This includes abstractions for all the necessary components for Direct3D:
 - Device
 - Command Queue
 - Command List & Command Allocator
 - Swapchain
 - Fence
 - Descriptor Heap & Resources (Render Targer & Depth Stencil Buffer)

Tools were created to:
 - Validate the result of WinAPI and DX12 API calls
 - Logging

CMake is used as the build system, and all logging is disabled in release mode as well as the special console allocated for it.

*For more information about implementation details check the documentation*  